### PR TITLE
Download from remote direct http/https url for base config (and config)

### DIFF
--- a/fvcore/common/config.py
+++ b/fvcore/common/config.py
@@ -5,8 +5,6 @@ import logging
 import os
 from typing import Any
 import yaml
-import urllib
-import requests
 from yacs.config import CfgNode as _CfgNode
 
 BASE_KEY = "_BASE_"
@@ -46,25 +44,22 @@ class CfgNode(_CfgNode):
         Returns:
             (dict): the loaded yaml
         """
-        if urllib.parse.urlparse(filename).scheme in ('http', 'https',):
-            cfg = yaml.safe_load(requests.get(filename).text)
-        else:
-            with open(filename, "r") as f:
-                try:
-                    cfg = yaml.safe_load(f)
-                except yaml.constructor.ConstructorError:
-                    if not allow_unsafe:
-                        raise
-                    logger = logging.getLogger(__name__)
-                    logger.warning(
-                        "Loading config {} with yaml.unsafe_load. Your machine may "
-                        "be at risk if the file contains malicious content.".format(
-                            filename
-                        )
+        with open(filename, "r") as f:
+            try:
+                cfg = yaml.safe_load(f)
+            except yaml.constructor.ConstructorError:
+                if not allow_unsafe:
+                    raise
+                logger = logging.getLogger(__name__)
+                logger.warning(
+                    "Loading config {} with yaml.unsafe_load. Your machine may "
+                    "be at risk if the file contains malicious content.".format(
+                        filename
                     )
-                    f.close()
-                    with open(filename, "r") as f:
-                        cfg = yaml.unsafe_load(f)
+                )
+                f.close()
+                with open(filename, "r") as f:
+                    cfg = yaml.unsafe_load(f)
 
         def merge_a_into_b(a, b):
             # merge dict a into dict b. values in a will overwrite b.

--- a/fvcore/common/config.py
+++ b/fvcore/common/config.py
@@ -7,6 +7,8 @@ from typing import Any
 import yaml
 from yacs.config import CfgNode as _CfgNode
 
+from fvcore.common.file_io import PathManager
+
 BASE_KEY = "_BASE_"
 
 
@@ -44,7 +46,7 @@ class CfgNode(_CfgNode):
         Returns:
             (dict): the loaded yaml
         """
-        with open(filename, "r") as f:
+        with PathManager.open(filename, "r") as f:
             try:
                 cfg = yaml.safe_load(f)
             except yaml.constructor.ConstructorError:


### PR DESCRIPTION
Allow the download from direct urls of configs (mainly for base configs):
```
_BASE_: "https://raw.githubusercontent.com/facebookresearch/detectron2/master/configs/Base-RCNN-DilatedC5.yaml"
MODEL:
  WEIGHTS: "detectron2://ImageNetPretrained/MSRA/R-50.pkl"
  MASK_ON: True
  RESNETS:
    DEPTH: 50
```