### PR TITLE
fix max_to_keep of periodic checkpointer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 *.py[cod]
+*egg-info*
 
 # C extensions
 *.so

--- a/fvcore/common/checkpoint.py
+++ b/fvcore/common/checkpoint.py
@@ -278,6 +278,8 @@ class PeriodicCheckpointer:
         self.checkpointer = checkpointer
         self.period = int(period)
         self.max_iter = max_iter
+        if max_to_keep is not None:
+            assert max_to_keep > 0
         self.max_to_keep = max_to_keep
         self.recent_checkpoints = []
 
@@ -301,7 +303,7 @@ class PeriodicCheckpointer:
                 self.checkpointer.get_checkpoint_file()
             )
 
-            if self.max_to_keep is not None and self.max_to_keep > 0:
+            if self.max_to_keep is not None:
                 if len(self.recent_checkpoints) > self.max_to_keep:
                     file_to_delete = self.recent_checkpoints.pop(0)
                     if PathManager.exists(

--- a/fvcore/common/checkpoint.py
+++ b/fvcore/common/checkpoint.py
@@ -299,11 +299,11 @@ class PeriodicCheckpointer:
             self.checkpointer.save(
                 "model_{:07d}".format(iteration), **additional_state
             )
-            self.recent_checkpoints.append(
-                self.checkpointer.get_checkpoint_file()
-            )
 
             if self.max_to_keep is not None:
+                self.recent_checkpoints.append(
+                    self.checkpointer.get_checkpoint_file()
+                )
                 if len(self.recent_checkpoints) > self.max_to_keep:
                     file_to_delete = self.recent_checkpoints.pop(0)
                     if PathManager.exists(

--- a/fvcore/common/checkpoint.py
+++ b/fvcore/common/checkpoint.py
@@ -306,8 +306,9 @@ class PeriodicCheckpointer:
                     item
                     for item in all_checkpoint_files
                     if not item.endswith("model_final.pth")
-                    and item != last_ckpt_file
+                    and (item != last_ckpt_file or iteration >= self.max_iter - 1)
                 ]
+
                 all_checkpoint_files.sort()
                 files_to_delete = all_checkpoint_files[: -self.max_to_keep]
 

--- a/fvcore/common/checkpoint.py
+++ b/fvcore/common/checkpoint.py
@@ -306,7 +306,9 @@ class PeriodicCheckpointer:
                     item
                     for item in all_checkpoint_files
                     if not item.endswith("model_final.pth")
-                    and (item != last_ckpt_file or iteration >= self.max_iter - 1)
+                    and (
+                        item != last_ckpt_file or iteration >= self.max_iter - 1
+                    )
                 ]
 
                 all_checkpoint_files.sort()

--- a/fvcore/common/checkpoint.py
+++ b/fvcore/common/checkpoint.py
@@ -301,10 +301,12 @@ class PeriodicCheckpointer:
                 all_checkpoint_files = (
                     self.checkpointer.get_all_checkpoint_files()
                 )
+                last_ckpt_file = self.checkpointer.get_checkpoint_file()
                 all_checkpoint_files = [
                     item
                     for item in all_checkpoint_files
                     if not item.endswith("model_final.pth")
+                    and item != last_ckpt_file
                 ]
                 all_checkpoint_files.sort()
                 files_to_delete = all_checkpoint_files[: -self.max_to_keep]

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -241,19 +241,19 @@ class TestPeriodicCheckpointer(unittest.TestCase):
                 periodic_checkpointer = PeriodicCheckpointer(
                     checkpointer, _period, 99, max_to_keep=_max_to_keep
                 )
+                for _ in range(2):
+                    checkpoint_paths = []
 
-                checkpoint_paths = []
+                    for iteration in range(_max_iter):
+                        periodic_checkpointer.step(iteration)
+                        if (iteration + 1) % _period == 0:
+                            path = os.path.join(
+                                f, "model_{:07d}.pth".format(iteration)
+                            )
+                            checkpoint_paths.append(path)
 
-                for iteration in range(_max_iter):
-                    periodic_checkpointer.step(iteration)
-                    if (iteration + 1) % _period == 0:
-                        path = os.path.join(
-                            f, "model_{:07d}.pth".format(iteration)
-                        )
-                        checkpoint_paths.append(path)
+                    for path in checkpoint_paths[:-_max_to_keep]:
+                        self.assertFalse(os.path.exists(path))
 
-                for path in checkpoint_paths[:-_max_to_keep]:
-                    self.assertFalse(os.path.exists(path))
-
-                for path in checkpoint_paths[-_max_to_keep:]:
-                    self.assertTrue(os.path.exists(path))
+                    for path in checkpoint_paths[-_max_to_keep:]:
+                        self.assertTrue(os.path.exists(path))


### PR DESCRIPTION
When `max_to_keep is not None` and user restarts the training, the last_checkpoint might be deleted.