### PR TITLE
Fix typo in isort cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = True
-force_grid_warp = 0
+force_grid_wrap = 0
 default_section = THIRDPARTY
 lines_after_imports = 2
 combine_as_imports = True


### PR DESCRIPTION
No option named "force_grid_warp" in sort configuration.

Was supposed to be merged with #46 