### PR TITLE
Per module jit analysis for flop count.

### DIFF
--- a/fvcore/nn/__init__.py
+++ b/fvcore/nn/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
-from .activation_count import activation_count
-from .flop_count import flop_count
+from .activation_count import ActivationCount, activation_count
+from .flop_count import FlopCount, flop_count
 from .focal_loss import (
     sigmoid_focal_loss,
     sigmoid_focal_loss_jit,

--- a/fvcore/nn/activation_count.py
+++ b/fvcore/nn/activation_count.py
@@ -1,22 +1,23 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # pyre-ignore-all-errors[2,33]
 
-import torch.nn as nn
 from collections import defaultdict
 from typing import (
-    Any, 
-    Callable, 
-    Counter, 
-    DefaultDict, 
-    Dict, 
-    List, 
-    Tuple, 
+    Any,
+    Callable,
+    Counter,
+    DefaultDict,
+    Dict,
+    List,
+    Optional,
+    Tuple,
     Union,
-    Optional
 )
 
+import torch.nn as nn
+
 from .jit_analysis import JitModelAnalysis
-from .jit_handles import generic_activation_jit, Handle
+from .jit_handles import Handle, generic_activation_jit
 
 
 # A dictionary that maps supported operations to their activation count handles.
@@ -24,6 +25,7 @@ _DEFAULT_SUPPORTED_OPS: Dict[str, Handle] = {
     "aten::_convolution": generic_activation_jit("conv"),
     "aten::addmm": generic_activation_jit("addmm"),
 }
+
 
 class ActivationCount(JitModelAnalysis):
     """
@@ -35,7 +37,7 @@ class ActivationCount(JitModelAnalysis):
     aten::_convolution, used by convolutional layers
 
     Handles for additional may be added, or the default ones overwritten,
-    using the 'additional_ops' input at initialization or the 
+    using the 'additional_ops' input at initialization or the
     .set_op_handle(name, func) method.
 
     Activation counts can be obtained as:
@@ -43,20 +45,21 @@ class ActivationCount(JitModelAnalysis):
     .total(module="") : total activation count for the module
     .by_operator(module="") : activation counts for the module, as a
         dictionary over different operator types
-    .by_module() : dictionary of activation counts for all descendants 
+    .by_module() : dictionary of activation counts for all descendants
         of the model,
     .by_module_and_operator() : dictionary indexed by descendant of dictionaries
         over different operator types
 
     Modules may be referenced using their name as a string (where the
     input model is "") or using the reference to the module itelf.
-        
+
     """
+
     def __init__(
         self,
         model: nn.Module,
         inputs: Tuple[Any, ...],
-        additional_ops: Optional[Dict[str, Handle]] = None
+        additional_ops: Optional[Dict[str, Handle]] = None,
     ) -> None:
         """
         Args:
@@ -64,17 +67,15 @@ class ActivationCount(JitModelAnalysis):
             inputs (tuple) : The inputs to the model for analysis.
             additional_ops (dict(str,Callable) : Map an operator name in the
                 trace graph to a function used to calculate the activation
-                The function must take the inputs and outputs of the op, 
-                each as a list(torch._C.Value), and returns a counter of 
+                The function must take the inputs and outputs of the op,
+                each as a list(torch._C.Value), and returns a counter of
                 the form {op_name : number}. This adds to or overwrites
-                the default activation handles for aten::addmm and 
+                the default activation handles for aten::addmm and
                 aten::_convolution.
         """
         ops_handles = {**_DEFAULT_SUPPORTED_OPS, **(additional_ops or {})}
         super(ActivationCount, self).__init__(
-            model=model,
-            inputs=inputs,
-            ops_handles=ops_handles
+            model=model, inputs=inputs, ops_handles=ops_handles
         )
 
 

--- a/fvcore/nn/activation_count.py
+++ b/fvcore/nn/activation_count.py
@@ -1,13 +1,15 @@
-import typing
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+# pyre-ignore-all-errors[2,33]
 
 import torch.nn as nn
-from fvcore.nn.jit_analysis import JitModelAnalysis
-from fvcore.nn.jit_handles import generic_activation_jit
+from typing import Any, Callable, Counter, DefaultDict, Dict, List, Tuple, Union
+
+from .jit_analysis import JitModelAnalysis
+from .jit_handles import generic_activation_jit, Handle
 
 
 # A dictionary that maps supported operations to their activation count handles.
-# pyre-fixme[24]: Generic type `typing.Callable` expects 2 type parameters.
-_DEFAULT_SUPPORTED_OPS: typing.Dict[str, typing.Callable] = {
+_DEFAULT_SUPPORTED_OPS: Dict[str, Handle] = {
     "aten::_convolution": generic_activation_jit("conv"),
     "aten::addmm": generic_activation_jit("addmm"),
 }
@@ -43,13 +45,13 @@ def default_activation_counter(
 
 def activation_count(
     model: nn.Module,
-    inputs: typing.Tuple[object, ...],
-    # pyre-fixme[24]: Generic type `typing.Callable` expects 2 type parameters.
-    supported_ops: typing.Union[typing.Dict[str, typing.Callable], None] = None,
-) -> typing.Tuple[typing.DefaultDict[str, float], typing.Counter[str]]:
+    inputs: Tuple[Any, ...],
+    supported_ops: Union[Dict[str, Handle], None] = None,
+) -> Tuple[DefaultDict[str, float], Counter[str]]:
     """
     Given a model and an input to the model, compute the total number of
     activations of the model.
+
     Args:
         model (nn.Module): The model to compute activation counts.
         inputs (tuple): Inputs that are passed to `model` to count activations.
@@ -58,6 +60,7 @@ def activation_count(
             handlers for extra ops, or overwrite the existing handlers for
             convolution and matmul. The key is operator name and the value
             is a function that takes (inputs, outputs) of the op.
+
     Returns:
         tuple[defaultdict, Counter]: A dictionary that records the number of
             activation (mega) for each operation and a Counter that records the

--- a/fvcore/nn/activation_count.py
+++ b/fvcore/nn/activation_count.py
@@ -1,32 +1,55 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
-# pyre-ignore-all-errors[2,33]
-
-import logging
-from collections import defaultdict
-from typing import Any, Callable, Counter, DefaultDict, Dict, List, Tuple, Union
+import typing
 
 import torch.nn as nn
+from fvcore.nn.jit_analysis import JitModelAnalysis
+from fvcore.nn.jit_handles import generic_activation_jit
 
-from .jit_handles import generic_activation_jit, get_jit_model_analysis
 
-
-Handle = Callable[[List[Any], List[Any]], Counter[str]]
 # A dictionary that maps supported operations to their activation count handles.
-_DEFAULT_SUPPORTED_OPS: Dict[str, Handle] = {
+# pyre-fixme[24]: Generic type `typing.Callable` expects 2 type parameters.
+_DEFAULT_SUPPORTED_OPS: typing.Dict[str, typing.Callable] = {
     "aten::_convolution": generic_activation_jit("conv"),
     "aten::addmm": generic_activation_jit("addmm"),
 }
 
 
+def default_activation_counter(
+    model: nn.Module,
+    inputs: typing.Tuple[object, ...],
+    additional_ops: typing.Dict[str, typing.Callable] = {},
+) -> JitModelAnalysis:
+    """
+    Constructs a JitModelAnalysis class configured for activation counting.
+    By default, counts the flops for convolutional and linear layers and
+    returns results in mega-activations.
+    Args:
+        model (nn.Module): The model to compute flop counts.
+        inputs (tuple): Inputs that are passed to `model` to count flops.
+            Inputs need to be in a tuple.
+        additional_ops (dict(str,Callable) or None) : provide additional
+            handlers for extra ops, or overwrite the existing handlers for
+            convolution and matmul and einsum. The key is operator name and the value
+            is a function that takes (inputs, outputs) of the op. We count
+            one Multiply-Add as one FLOP.
+    Returns:
+        JitModelAnalysis : computes and stores flop counts, organized
+            by module and by operator type.
+    """
+    ops_handles = {**_DEFAULT_SUPPORTED_OPS, **(additional_ops or {})}
+    act_counter = JitModelAnalysis(model, inputs, ops_handles)
+    act_counter.set_output_scale("mega")
+    return act_counter
+
+
 def activation_count(
     model: nn.Module,
-    inputs: Tuple[Any, ...],
-    supported_ops: Union[Dict[str, Handle], None] = None,
-) -> Tuple[DefaultDict[str, float], Counter[str]]:
+    inputs: typing.Tuple[object, ...],
+    # pyre-fixme[24]: Generic type `typing.Callable` expects 2 type parameters.
+    supported_ops: typing.Union[typing.Dict[str, typing.Callable], None] = None,
+) -> typing.Tuple[typing.DefaultDict[str, float], typing.Counter[str]]:
     """
     Given a model and an input to the model, compute the total number of
     activations of the model.
-
     Args:
         model (nn.Module): The model to compute activation counts.
         inputs (tuple): Inputs that are passed to `model` to count activations.
@@ -35,29 +58,11 @@ def activation_count(
             handlers for extra ops, or overwrite the existing handlers for
             convolution and matmul. The key is operator name and the value
             is a function that takes (inputs, outputs) of the op.
-
     Returns:
         tuple[defaultdict, Counter]: A dictionary that records the number of
             activation (mega) for each operation and a Counter that records the
             number of skipped operations.
     """
-    assert isinstance(inputs, tuple), "Inputs need to be in a tuple."
-    supported_ops = {**_DEFAULT_SUPPORTED_OPS, **(supported_ops or {})}
 
-    # Run activation count.
-    total_activation_count, skipped_ops = get_jit_model_analysis(
-        model, inputs, supported_ops
-    )
-
-    # Log for skipped operations.
-    logger = logging.getLogger(__name__)
-    if len(skipped_ops) > 0:
-        for op, freq in skipped_ops.items():
-            logger.warning("Skipped operation {} {} time(s)".format(op, freq))
-
-    # Convert activation count to mega count.
-    final_count = defaultdict(float)
-    for op in total_activation_count:
-        final_count[op] = total_activation_count[op] / 1e6
-
-    return final_count, skipped_ops
+    act_counter = default_activation_counter(model, inputs, supported_ops)
+    return act_counter.by_operator(), act_counter.skipped_ops()

--- a/fvcore/nn/activation_count.py
+++ b/fvcore/nn/activation_count.py
@@ -2,7 +2,18 @@
 # pyre-ignore-all-errors[2,33]
 
 import torch.nn as nn
-from typing import Any, Callable, Counter, DefaultDict, Dict, List, Tuple, Union
+from collections import defaultdict
+from typing import (
+    Any, 
+    Callable, 
+    Counter, 
+    DefaultDict, 
+    Dict, 
+    List, 
+    Tuple, 
+    Union,
+    Optional
+)
 
 from .jit_analysis import JitModelAnalysis
 from .jit_handles import generic_activation_jit, Handle
@@ -14,33 +25,57 @@ _DEFAULT_SUPPORTED_OPS: Dict[str, Handle] = {
     "aten::addmm": generic_activation_jit("addmm"),
 }
 
+class ActivationCount(JitModelAnalysis):
+    """
+    Provides access to per-submodule model activation count obtained by
+    tracing a model with pytorch's jit tracing functionality. By default,
+    comes with standard activation counters for two operators:
 
-def default_activation_counter(
-    model: nn.Module,
-    inputs: typing.Tuple[object, ...],
-    additional_ops: typing.Dict[str, typing.Callable] = {},
-) -> JitModelAnalysis:
+    aten::addmm, used by linear layers
+    aten::_convolution, used by convolutional layers
+
+    Handles for additional may be added, or the default ones overwritten,
+    using the 'additional_ops' input at initialization or the 
+    .set_op_handle(name, func) method.
+
+    Activation counts can be obtained as:
+
+    .total(module="") : total activation count for the module
+    .by_operator(module="") : activation counts for the module, as a
+        dictionary over different operator types
+    .by_module() : dictionary of activation counts for all descendants 
+        of the model,
+    .by_module_and_operator() : dictionary indexed by descendant of dictionaries
+        over different operator types
+
+    Modules may be referenced using their name as a string (where the
+    input model is "") or using the reference to the module itelf.
+        
     """
-    Constructs a JitModelAnalysis class configured for activation counting.
-    By default, counts the flops for convolutional and linear layers and
-    returns results in mega-activations.
-    Args:
-        model (nn.Module): The model to compute flop counts.
-        inputs (tuple): Inputs that are passed to `model` to count flops.
-            Inputs need to be in a tuple.
-        additional_ops (dict(str,Callable) or None) : provide additional
-            handlers for extra ops, or overwrite the existing handlers for
-            convolution and matmul and einsum. The key is operator name and the value
-            is a function that takes (inputs, outputs) of the op. We count
-            one Multiply-Add as one FLOP.
-    Returns:
-        JitModelAnalysis : computes and stores flop counts, organized
-            by module and by operator type.
-    """
-    ops_handles = {**_DEFAULT_SUPPORTED_OPS, **(additional_ops or {})}
-    act_counter = JitModelAnalysis(model, inputs, ops_handles)
-    act_counter.set_output_scale("mega")
-    return act_counter
+    def __init__(
+        self,
+        model: nn.Module,
+        inputs: Tuple[Any, ...],
+        additional_ops: Optional[Dict[str, Handle]] = None
+    ) -> None:
+        """
+        Args:
+            model (nn.Module) : The model to analyze
+            inputs (tuple) : The inputs to the model for analysis.
+            additional_ops (dict(str,Callable) : Map an operator name in the
+                trace graph to a function used to calculate the activation
+                The function must take the inputs and outputs of the op, 
+                each as a list(torch._C.Value), and returns a counter of 
+                the form {op_name : number}. This adds to or overwrites
+                the default activation handles for aten::addmm and 
+                aten::_convolution.
+        """
+        ops_handles = {**_DEFAULT_SUPPORTED_OPS, **(additional_ops or {})}
+        super(ActivationCount, self).__init__(
+            model=model,
+            inputs=inputs,
+            ops_handles=ops_handles
+        )
 
 
 def activation_count(
@@ -67,5 +102,8 @@ def activation_count(
             number of skipped operations.
     """
 
-    act_counter = default_activation_counter(model, inputs, supported_ops)
-    return act_counter.by_operator(), act_counter.skipped_ops()
+    act_counter = ActivationCount(model, inputs, supported_ops)
+    mega_acts = defaultdict(float)
+    for op, act in act_counter.by_operator().items():
+        mega_acts[op] = act / 1e6
+    return mega_acts, act_counter.skipped_ops()

--- a/fvcore/nn/activation_count.py
+++ b/fvcore/nn/activation_count.py
@@ -40,8 +40,15 @@ class ActivationCount(JitModelAnalysis):
     .by_module_and_operator() : dictionary indexed by descendant of dictionaries
         over different operator types
 
-    Modules may be referenced using their name as a string (where the
-    input model is "") or using the reference to the module itelf.
+    Submodules may be referred to using the module's name. The input model has
+    name "", while its descendants have names of the form
+    "child.grandchild.grandgrandchild...".
+
+    An operator is treated as within the scope of a module if calling that
+    module directly resulted in that operator being run. In particular,
+    this means that calls to other functions owned by a module or explicit
+    calls to module.forward(...) will not register resulting operators as
+    contributing activations to that module.
 
     """
 

--- a/fvcore/nn/activation_count.py
+++ b/fvcore/nn/activation_count.py
@@ -2,17 +2,7 @@
 # pyre-ignore-all-errors[2,33]
 
 from collections import defaultdict
-from typing import (
-    Any,
-    Callable,
-    Counter,
-    DefaultDict,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Any, Counter, DefaultDict, Dict, Optional, Tuple, Union
 
 import torch.nn as nn
 

--- a/fvcore/nn/flop_count.py
+++ b/fvcore/nn/flop_count.py
@@ -2,7 +2,18 @@
 # pyre-ignore-all-errors[2,33]
 
 import torch.nn as nn
-from typing import Any, Callable, Counter, DefaultDict, Dict, List, Tuple, Union
+from collections import defaultdict
+from typing import (
+    Any, 
+    Callable, 
+    Counter, 
+    DefaultDict, 
+    Dict, 
+    List, 
+    Tuple, 
+    Union,
+    Optional
+)
 
 from .jit_analysis import JitModelAnalysis
 from .jit_handles import (
@@ -24,33 +35,59 @@ _DEFAULT_SUPPORTED_OPS: Dict[str, Handle] = {
     "aten::matmul": matmul_flop_jit,
 }
 
+class FlopCount(JitModelAnalysis):
+    """
+    Provides access to per-submodule model flop count obtained by
+    tracing a model with pytorch's jit tracing functionality. By default,
+    comes with standard flop counters for five operators:
 
-def default_flop_counter(
-    model: nn.Module,
-    inputs: typing.Tuple[object, ...],
-    additional_ops: typing.Dict[str, typing.Callable] = {},
-) -> JitModelAnalysis:
+    aten::addmm, used by linear layers
+    aten::_convolution, used by convolutional layers
+    aten::bmm, batch matrix multiply
+    aten::matmul, matrix multiplication
+    aten::einsum, Einstein notation summation
+
+    Handles for additional operators may be added, or the default ones 
+    overwritten, using the 'additional_ops' input at initialization or the 
+    .set_op_handle(name, func) method.
+
+    Flop counts can be obtained as:
+
+    .total(module="") : total flop count for the module
+    .by_operator(module="") : flpo counts for the module, as a dictionary 
+        over different operator types
+    .by_module() : dictionary of flop counts for all descendants 
+        of the model,
+    .by_module_and_operator() : dictionary indexed by descendant of dictionaries
+        over different operator types
+
+    Modules may be referenced using their name as a string (where the
+    input model is "") or using the reference to the module itelf.
+        
     """
-    Constructs a JitModelAnalysis class configured for flop counting.
-    By default, counts the flops for convolutions and matrix
-    matrix multiplications, and reports results in Gflops.
-    Args:
-        model (nn.Module): The model to compute flop counts.
-        inputs (tuple): Inputs that are passed to `model` to count flops.
-            Inputs need to be in a tuple.
-        additional_ops (dict(str,Callable) or None) : provide additional
-            handlers for extra ops, or overwrite the existing handlers for
-            convolution and matmul and einsum. The key is operator name and the value
-            is a function that takes (inputs, outputs) of the op. We count
-            one Multiply-Add as one FLOP.
-    Returns:
-        JitModelAnalysis : computes and stores flop counts, organized
-            by module and by operator type.
-    """
-    ops_handles = {**_DEFAULT_SUPPORTED_OPS, **(additional_ops or {})}
-    flop_counter = JitModelAnalysis(model, inputs, ops_handles)
-    flop_counter.set_output_scale("giga")
-    return flop_counter
+    def __init__(
+        self,
+        model: nn.Module,
+        inputs: Tuple[Any, ...],
+        additional_ops: Optional[Dict[str, Handle]] = None
+    ) -> None:
+        """
+        Args:
+            model (nn.Module) : The model to analyze
+            inputs (tuple) : The inputs to the model for analysis.
+            additional_ops (dict(str,Callable) : Map an operator name in the
+                trace graph to a function used to calculate the flop.
+                The function must take the inputs and outputs of the op, 
+                each as a list(torch._C.Value), and returns a counter of 
+                the form {op_name : number}. This adds to or overwrites
+                the default flop  handles. 
+        """
+        ops_handles = {**_DEFAULT_SUPPORTED_OPS, **(additional_ops or {})}
+        super(FlopCount, self).__init__(
+            model=model,
+            inputs=inputs,
+            ops_handles=ops_handles
+        )
 
 
 def flop_count(
@@ -77,5 +114,9 @@ def flop_count(
             gflops for each operation and a Counter that records the number of
             skipped operations.
     """
-    flop_counter = default_flop_counter(model, inputs, supported_ops)
-    return flop_counter.by_operator(), flop_counter.skipped_ops()
+
+    flop_counter = FlopCount(model, inputs, supported_ops)
+    giga_flops = defaultdict(float)
+    for op, flop in flop_counter.by_operator().items():
+        giga_flops[op] = flop / 1e9
+    return giga_flops, flop_counter.skipped_ops()

--- a/fvcore/nn/flop_count.py
+++ b/fvcore/nn/flop_count.py
@@ -1,19 +1,20 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # pyre-ignore-all-errors[2,33]
 
-import torch.nn as nn
 from collections import defaultdict
 from typing import (
-    Any, 
-    Callable, 
-    Counter, 
-    DefaultDict, 
-    Dict, 
-    List, 
-    Tuple, 
+    Any,
+    Callable,
+    Counter,
+    DefaultDict,
+    Dict,
+    List,
+    Optional,
+    Tuple,
     Union,
-    Optional
 )
+
+import torch.nn as nn
 
 from .jit_analysis import JitModelAnalysis
 from .jit_handles import (
@@ -35,6 +36,7 @@ _DEFAULT_SUPPORTED_OPS: Dict[str, Handle] = {
     "aten::matmul": matmul_flop_jit,
 }
 
+
 class FlopCount(JitModelAnalysis):
     """
     Provides access to per-submodule model flop count obtained by
@@ -47,29 +49,30 @@ class FlopCount(JitModelAnalysis):
     aten::matmul, matrix multiplication
     aten::einsum, Einstein notation summation
 
-    Handles for additional operators may be added, or the default ones 
-    overwritten, using the 'additional_ops' input at initialization or the 
+    Handles for additional operators may be added, or the default ones
+    overwritten, using the 'additional_ops' input at initialization or the
     .set_op_handle(name, func) method.
 
     Flop counts can be obtained as:
 
     .total(module="") : total flop count for the module
-    .by_operator(module="") : flpo counts for the module, as a dictionary 
+    .by_operator(module="") : flpo counts for the module, as a dictionary
         over different operator types
-    .by_module() : dictionary of flop counts for all descendants 
+    .by_module() : dictionary of flop counts for all descendants
         of the model,
     .by_module_and_operator() : dictionary indexed by descendant of dictionaries
         over different operator types
 
     Modules may be referenced using their name as a string (where the
     input model is "") or using the reference to the module itelf.
-        
+
     """
+
     def __init__(
         self,
         model: nn.Module,
         inputs: Tuple[Any, ...],
-        additional_ops: Optional[Dict[str, Handle]] = None
+        additional_ops: Optional[Dict[str, Handle]] = None,
     ) -> None:
         """
         Args:
@@ -77,16 +80,14 @@ class FlopCount(JitModelAnalysis):
             inputs (tuple) : The inputs to the model for analysis.
             additional_ops (dict(str,Callable) : Map an operator name in the
                 trace graph to a function used to calculate the flop.
-                The function must take the inputs and outputs of the op, 
-                each as a list(torch._C.Value), and returns a counter of 
+                The function must take the inputs and outputs of the op,
+                each as a list(torch._C.Value), and returns a counter of
                 the form {op_name : number}. This adds to or overwrites
-                the default flop  handles. 
+                the default flop  handles.
         """
         ops_handles = {**_DEFAULT_SUPPORTED_OPS, **(additional_ops or {})}
         super(FlopCount, self).__init__(
-            model=model,
-            inputs=inputs,
-            ops_handles=ops_handles
+            model=model, inputs=inputs, ops_handles=ops_handles
         )
 
 

--- a/fvcore/nn/flop_count.py
+++ b/fvcore/nn/flop_count.py
@@ -1,25 +1,17 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
-# pyre-ignore-all-errors[2,33]
-
-import logging
-from collections import defaultdict
-from typing import Any, Callable, Counter, DefaultDict, Dict, List, Tuple, Union
+import typing
 
 import torch.nn as nn
-
-from .jit_handles import (
+from fvcore.nn.jit_analysis import JitModelAnalysis
+from fvcore.nn.jit_handles import (
     addmm_flop_jit,
     bmm_flop_jit,
     conv_flop_jit,
     einsum_flop_jit,
-    get_jit_model_analysis,
     matmul_flop_jit,
 )
 
 
-Handle = Callable[[List[Any], List[Any]], Counter[str]]
-# A dictionary that maps supported operations to their flop count jit handles.
-_DEFAULT_SUPPORTED_OPS: Dict[str, Handle] = {
+_DEFAULT_SUPPORTED_OPS: typing.Dict[str, typing.Callable] = {
     "aten::addmm": addmm_flop_jit,
     "aten::bmm": bmm_flop_jit,
     "aten::_convolution": conv_flop_jit,
@@ -28,15 +20,43 @@ _DEFAULT_SUPPORTED_OPS: Dict[str, Handle] = {
 }
 
 
+def default_flop_counter(
+    model: nn.Module,
+    inputs: typing.Tuple[object, ...],
+    additional_ops: typing.Dict[str, typing.Callable] = {},
+) -> JitModelAnalysis:
+    """
+    Constructs a JitModelAnalysis class configured for flop counting.
+    By default, counts the flops for convolutions and matrix
+    matrix multiplications, and reports results in Gflops.
+    Args:
+        model (nn.Module): The model to compute flop counts.
+        inputs (tuple): Inputs that are passed to `model` to count flops.
+            Inputs need to be in a tuple.
+        additional_ops (dict(str,Callable) or None) : provide additional
+            handlers for extra ops, or overwrite the existing handlers for
+            convolution and matmul and einsum. The key is operator name and the value
+            is a function that takes (inputs, outputs) of the op. We count
+            one Multiply-Add as one FLOP.
+    Returns:
+        JitModelAnalysis : computes and stores flop counts, organized
+            by module and by operator type.
+    """
+    ops_handles = {**_DEFAULT_SUPPORTED_OPS, **(additional_ops or {})}
+    flop_counter = JitModelAnalysis(model, inputs, ops_handles)
+    flop_counter.set_output_scale("giga")
+    return flop_counter
+
+
 def flop_count(
     model: nn.Module,
-    inputs: Tuple[Any, ...],
-    supported_ops: Union[Dict[str, Handle], None] = None,
-) -> Tuple[DefaultDict[str, float], Counter[str]]:
+    inputs: typing.Tuple[object, ...],
+    # pyre-fixme[24]: Generic type `typing.Callable` expects 2 type parameters.
+    supported_ops: typing.Union[typing.Dict[str, typing.Callable], None] = None,
+) -> typing.Tuple[typing.DefaultDict[str, float], typing.Counter[str]]:
     """
     Given a model and an input to the model, compute the Gflops of the given
     model.
-
     Args:
         model (nn.Module): The model to compute flop counts.
         inputs (tuple): Inputs that are passed to `model` to count flops.
@@ -46,29 +66,10 @@ def flop_count(
             convolution and matmul and einsum. The key is operator name and the value
             is a function that takes (inputs, outputs) of the op. We count
             one Multiply-Add as one FLOP.
-
     Returns:
         tuple[defaultdict, Counter]: A dictionary that records the number of
             gflops for each operation and a Counter that records the number of
             skipped operations.
     """
-    assert isinstance(inputs, tuple), "Inputs need to be in a tuple."
-    supported_ops = {**_DEFAULT_SUPPORTED_OPS, **(supported_ops or {})}
-
-    # Run flop count.
-    total_flop_counter, skipped_ops = get_jit_model_analysis(
-        model, inputs, supported_ops
-    )
-
-    # Log for skipped operations.
-    logger = logging.getLogger(__name__)
-    if len(skipped_ops) > 0:
-        for op, freq in skipped_ops.items():
-            logger.warning("Skipped operation {} {} time(s)".format(op, freq))
-
-    # Convert flop count to gigaflops.
-    final_count = defaultdict(float)
-    for op in total_flop_counter:
-        final_count[op] = total_flop_counter[op] / 1e9
-
-    return final_count, skipped_ops
+    flop_counter = default_flop_counter(model, inputs, supported_ops)
+    return flop_counter.by_operator(), flop_counter.skipped_ops()

--- a/fvcore/nn/flop_count.py
+++ b/fvcore/nn/flop_count.py
@@ -31,7 +31,8 @@ class FlopCount(JitModelAnalysis):
     """
     Provides access to per-submodule model flop count obtained by
     tracing a model with pytorch's jit tracing functionality. By default,
-    comes with standard flop counters for five operators:
+    comes with standard flop counters for five operators, which count one
+    Multiply-Add as one FLOP:
 
     aten::addmm, used by linear layers
     aten::_convolution, used by convolutional layers
@@ -53,8 +54,15 @@ class FlopCount(JitModelAnalysis):
     .by_module_and_operator() : dictionary indexed by descendant of dictionaries
         over different operator types
 
-    Modules may be referenced using their name as a string (where the
-    input model is "") or using the reference to the module itelf.
+    Submodules may be referred to using the module's name. The input model has
+    name "", while its descendants have names of the form
+    "child.grandchild.grandgrandchild...".
+
+    An operator is treated as within the scope of a module if calling that
+    module directly resulted in that operator being run. In particular,
+    this means that calls to other functions owned by a module or explicit
+    calls to module.forward(...) will not register resulting operators as
+    contributing flops to that module.
 
     """
 

--- a/fvcore/nn/flop_count.py
+++ b/fvcore/nn/flop_count.py
@@ -1,8 +1,12 @@
-import typing
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+# pyre-ignore-all-errors[2,33]
 
 import torch.nn as nn
-from fvcore.nn.jit_analysis import JitModelAnalysis
-from fvcore.nn.jit_handles import (
+from typing import Any, Callable, Counter, DefaultDict, Dict, List, Tuple, Union
+
+from .jit_analysis import JitModelAnalysis
+from .jit_handles import (
+    Handle,
     addmm_flop_jit,
     bmm_flop_jit,
     conv_flop_jit,
@@ -11,7 +15,8 @@ from fvcore.nn.jit_handles import (
 )
 
 
-_DEFAULT_SUPPORTED_OPS: typing.Dict[str, typing.Callable] = {
+# A dictionary that maps supported operations to their flop count jit handles.
+_DEFAULT_SUPPORTED_OPS: Dict[str, Handle] = {
     "aten::addmm": addmm_flop_jit,
     "aten::bmm": bmm_flop_jit,
     "aten::_convolution": conv_flop_jit,
@@ -50,13 +55,13 @@ def default_flop_counter(
 
 def flop_count(
     model: nn.Module,
-    inputs: typing.Tuple[object, ...],
-    # pyre-fixme[24]: Generic type `typing.Callable` expects 2 type parameters.
-    supported_ops: typing.Union[typing.Dict[str, typing.Callable], None] = None,
-) -> typing.Tuple[typing.DefaultDict[str, float], typing.Counter[str]]:
+    inputs: Tuple[Any, ...],
+    supported_ops: Union[Dict[str, Handle], None] = None,
+) -> Tuple[DefaultDict[str, float], Counter[str]]:
     """
     Given a model and an input to the model, compute the Gflops of the given
     model.
+
     Args:
         model (nn.Module): The model to compute flop counts.
         inputs (tuple): Inputs that are passed to `model` to count flops.
@@ -66,6 +71,7 @@ def flop_count(
             convolution and matmul and einsum. The key is operator name and the value
             is a function that takes (inputs, outputs) of the op. We count
             one Multiply-Add as one FLOP.
+
     Returns:
         tuple[defaultdict, Counter]: A dictionary that records the number of
             gflops for each operation and a Counter that records the number of

--- a/fvcore/nn/flop_count.py
+++ b/fvcore/nn/flop_count.py
@@ -2,17 +2,7 @@
 # pyre-ignore-all-errors[2,33]
 
 from collections import defaultdict
-from typing import (
-    Any,
-    Callable,
-    Counter,
-    DefaultDict,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Any, Counter, DefaultDict, Dict, Optional, Tuple, Union
 
 import torch.nn as nn
 

--- a/fvcore/nn/jit_analysis.py
+++ b/fvcore/nn/jit_analysis.py
@@ -151,7 +151,11 @@ def _get_scoped_trace_graph(
     else:
         recurse_hooks(module, "")
 
-    graph, _ = _get_trace_graph(module, inputs)
+    if hasattr(torch.jit, "get_trace_graph"):
+        trace, _ = torch.jit.get_trace_graph(module, inputs)
+        graph = trace.graph()
+    else:
+        graph, _ = _get_trace_graph(module, inputs)
 
     for handle in hook_handles:
         handle.remove()

--- a/fvcore/nn/jit_analysis.py
+++ b/fvcore/nn/jit_analysis.py
@@ -1,0 +1,480 @@
+import logging
+import typing
+import warnings
+from collections import Counter
+from copy import copy
+
+import torch
+import torch.nn as nn
+from torch.jit import _get_trace_graph
+
+
+_IGNORED_OPS: typing.Set[str] = {
+    "aten::Int",
+    "aten::ScalarImplicit",
+    "aten::__and__",
+    "aten::arange",
+    "aten::cat",
+    "aten::chunk",
+    "aten::clamp",
+    "aten::clamp_",
+    "aten::constant_pad_nd",
+    "aten::contiguous",
+    "aten::copy_",
+    "aten::detach",
+    "aten::dropout",
+    "aten::empty",
+    "aten::eq",
+    "aten::expand",
+    "aten::flatten",
+    "aten::floor",
+    "aten::floor_divide",
+    "aten::full",
+    "aten::ge",
+    "aten::gt",
+    "aten::index",
+    "aten::index_put_",
+    "aten::max",
+    "aten::nonzero",
+    "aten::permute",
+    "aten::relu",
+    "aten::relu_",
+    "aten::remainder",
+    "aten::reshape",
+    "aten::select",
+    "aten::size",
+    "aten::slice",
+    "aten::split",
+    "aten::split_with_sizes",
+    "aten::squeeze",
+    "aten::stack",
+    "aten::t",
+    "aten::to",
+    "aten::transpose",
+    "aten::unsqueeze",
+    "aten::unsqueeze_",
+    "aten::view",
+    "aten::zeros",
+    "aten::zeros_like",
+    "prim::Constant",
+    "prim::ImplicitTensorToNum",
+    "prim::Int",
+    "prim::ListConstruct",
+    "prim::ListUnpack",
+    "prim::NumToTensor",
+    "prim::TupleConstruct",
+}
+
+
+def _get_scoped_trace_graph(
+    module: nn.Module, inputs: typing.Tuple[object, ...]
+) -> typing.Tuple[torch._C.Graph, typing.Dict[str or nn.Module, str]]:
+    """
+    Traces the provided module using torch.jit._get_trace_graph, but adds
+    submodule scope information to each graph node. The resulting graph
+    is in-lined and has all model parameters treated as inputs. The input
+    model has the scope name '', while its descendants have names of the
+    form 'child.grandchild.grandgrandchild...'.
+
+    Args:
+        model (nn.Module) : The module to trace
+        inputs (tuple) : Inputs used during the trace of the model
+
+    Returns:
+        graph (torch._C.Graph) : The pytorch JIT trace of the model
+        aliases (dict) : A dictionary of alternative names for each
+            submodule. This maps both the nn.module object itself to
+            its scope name in the graph, but also includes mappings
+            of alternative scope names if a module appears as a chile
+            of multiple different submodules.
+    """
+
+    class ScopePushHook(object):
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def __call__(
+            self, module: nn.Module, inputs: typing.Tuple[object, ...]
+        ) -> typing.Tuple[object, ...]:
+            tracing_state = torch._C._get_tracing_state()
+            if tracing_state:
+                name = self.name
+                tracing_state.push_scope(name)
+            return inputs
+
+    class ScopePopHook(object):
+        def __call__(
+            self,
+            module: nn.Module,
+            inputs: typing.Tuple[object, ...],
+            outputs: typing.Tuple[object, ...],
+        ) -> typing.Tuple[object, ...]:
+            tracing_state = torch._C._get_tracing_state()
+            if tracing_state:
+                tracing_state.pop_scope()
+            return outputs
+
+    aliases = {}
+    hook_handles = []
+
+    def register_hooks(mod: nn.Module, name: str) -> None:
+        prehook = mod.register_forward_pre_hook(ScopePushHook(name))
+        posthook = mod.register_forward_hook(ScopePopHook())
+        hook_handles.append(prehook)
+        hook_handles.append(posthook)
+
+    # This naming scheme for scopes matches the structure of
+    # fvcore.nn.parameter_count. Names may not be completely identical
+    # since the module structure may not be walked in the same order.
+    # It does not match the naming scheme used by torch.jit.trace(...).
+    def recurse_hooks(mod: nn.Module, name: str) -> None:
+        if mod not in aliases:
+            register_hooks(mod, name)
+            aliases[mod] = name
+        else:
+            # We've seen this submodule before. Add the new name to aliases
+            aliases[name] = aliases[mod]
+        for subname, child in mod.named_children():
+            if name != "":
+                subname = name + "." + subname
+            recurse_hooks(child, subname)
+
+    # Torch script does not support parallel torch models, but we still
+    # want the scope names to be correct for the complete module.
+    if isinstance(
+        module, (nn.parallel.distributed.DistributedDataParallel, nn.DataParallel)
+    ):
+        aliases[module] = ""
+        module = module.module
+        register_hooks(module, "")  # Push scope for the removed DataParallel wrapper
+        recurse_hooks(module, "module")
+    else:
+        recurse_hooks(module, "")
+
+    graph, _ = _get_trace_graph(module, inputs)
+
+    for handle in hook_handles:
+        handle.remove()
+
+    return graph, aliases
+
+
+class JitModelAnalysis(object):
+    """
+    Provides access to per-submodule model statistics obtained by
+    tracing a model with pytorch's jit tracing functionality. Calculates
+    a statistic on a per-operator basis using the provided set of functions
+    that acts on the inputs and outputs to the operator, then aggregates
+    this over modules in the model. Can return the aggregate statistic for
+    any submodule in the model. Is lazily evaluated, and will perform the
+    trace when a statistic is first requested. Changing the model, inputs,
+    or operator handles will cause the trace to be rerun on the next
+    request.
+
+    Submodules may be referred to using the nn.Module object itself, or
+    a string associated with the module's name. The input model has name
+    '', while its descendants have names of the form
+    'child.grandchild.grandgrandchild...'.
+    """
+
+    ignored_ops = _IGNORED_OPS
+
+    def __init__(
+        self,
+        model: nn.Module,
+        inputs: typing.Tuple[object, ...],
+        ops_handles: typing.Dict[str, typing.Callable] = {},
+    ) -> None:
+        """
+        Args:
+            model (nn.Module) : The model to analyze
+            inputs (tuple) : The inputs to the model for analysis.
+            ops_handles (dict(str,Callable) : Map an operator name in the
+                trace graph to a function used to calculate the desire
+                statistic. The function must take the inputs and outputs
+                of the op, each as a list(torch._C.Value), and returns
+                a counter of the form {op_name : number}.
+        """
+        self._model = model
+        self._inputs = inputs
+        self._ops_handles = ops_handles
+        self.counts = None
+        self._skipped_ops = None
+        self.warn_skipped = True
+        self.warn_trace = True
+        self.scale = 1
+
+    def total(self, module: str or nn.Module = "") -> int or float:
+        """
+        Returns the total aggregated statistic across all operators
+        for the requested module.
+
+        Args:
+            module (nn.Module or str) : The submodule to get data for.
+                Defaults to the entire model.
+        Returns:
+            int or float : The aggregated statistic
+        """
+        self._analyze()
+        module = self._canonical_module_name(module)
+        self._warn_skipped_ops(module)
+        total_count = sum([c for c in self.counts[module].values()])
+        return self._rescale_count(total_count)
+
+    def by_operator(self, module: str or nn.Module = "") -> typing.Counter[str]:
+        """
+        Returns the statistics for a requested module, separated out by
+        operator type. The operator handle determines the name associated
+        with each operator type.
+
+        Args:
+            module (nn.Module or str) : The submodule to get data for.
+                Defaults to the entire model.
+        Returns:
+            Counter(str) : The statistics for each operator.
+        """
+        self._analyze()
+        module = self._canonical_module_name(module)
+        self._warn_skipped_ops(module)
+        return self._rescale_dict(self.counts[module])
+
+    def by_module_and_operator(self) -> typing.Dict[str, typing.Counter[str]]:
+        """
+        Returns the statistics for all submodules, separated out by
+        operator type for each submodule. The operator handle determines
+        the name associated with each operator type.
+
+        Returns:
+            dict(str, Counter(str)) : The statistics for each submodule
+                and each operator. Organized per-module, labelled
+                by the submodule's name, then by operator name.
+        """
+        self._analyze()
+        self._warn_skipped_ops("")
+        counts = {}
+        for mod in self.counts:
+            counts[mod] = self._rescale_dict(self.counts[mod])
+        return counts
+
+    def by_module(self) -> typing.Counter[str]:
+        """
+        Returns the statistics for all submodules, aggregated over
+            all operators.
+
+        Returns:
+            Counter(str) : The statistics for each submodule
+                and each operator. Organized per-module, labelled
+                by the submodule's name.
+        """
+        self._analyze()
+        self._warn_skipped_ops("")
+        summed_counts = Counter()
+        for mod, results in self.counts.items():
+            summed_counts[mod] = sum([c for c in results.values()])
+        return self._rescale_dict(summed_counts)
+
+    def skipped_ops(self, module: str or nn.Module = "") -> typing.Counter[str]:
+        """
+        Lists the number of operators that were skipped because no
+        operator handle existed for them. Does not include operators
+        listed in _IGNORED_OPS.
+
+        Args:
+            module (nn.Module or str) : The submodule to skipped ops for.
+                Defaults to the entire model.
+        Returns:
+            Counter(str) : The number of each type of operator skipped.
+        """
+        self._analyze()
+        module = self._canonical_module_name(module)
+        return self._skipped_ops[module]
+
+    def set_ops_handle(self, name: str, func: typing.Callable) -> None:
+        """
+        Sets an additional operator handle, or replacing an existing one.
+
+        Args:
+            name (str) : The operator's name
+            func (Callable) : Function that calculates the desirable
+                statistic from an operator. Must take two arguments,
+                which are the inputs and outputs of the operator, in the
+                form of list(torch._C.Value).
+        """
+        self._ops_handles[name] = func
+        self.counts = None
+
+    def clear_ops_handles(self) -> None:
+        """
+        Clears all set operator handles.
+        """
+        self._ops_handles = {}
+        self.counts = None
+
+    def set_output_scale(self, scale: str or float) -> None:
+        """
+        Sets the scale of the output statistics.
+
+        Args:
+            scale (str or float) : The scale to output statistics with.
+                Can be a string in ['unity', 'kilo', 'mega', 'giga',
+                'tera', 'peta'] or a number to divide results by.
+        """
+        named_scales = {
+            "unity": 1,
+            "kilo": 1e3,
+            "mega": 1e6,
+            "giga": 1e9,
+            "tera": 1e12,
+            "peta": 1e15,
+        }
+        if scale in named_scales:
+            scale = named_scales[scale]
+        assert not isinstance(
+            scale, str
+        ), "Unrecognized scale name. Must be in {}.".format(list(named_scales.keys()))
+        self.scale = scale
+
+    def get_output_scale(self) -> float:
+        """
+        Gets the output scale of the statistics.
+
+        Returns:
+            float : the output scale divided by
+        """
+        return self.scale
+
+    def copy(
+        self,
+        new_model: nn.Module or None = None,
+        new_inputs: typing.Tuple[object, ...] or None = None,
+    ) -> "JitModelAnalysis":
+        """
+        Returns a copy of the JitModelAnalysis object, keeping all
+        settings, but potentially on a new model or new inputs.
+
+        Args:
+            new_model (nn.Module or None) : a new model for the new
+                JitModelAnalysis. If None, uses the original model.
+            new_inputs (typing.Tuple[object, ...] or None) : new inputs
+                for the new JitModelAnalysis. If None, uses the original
+                inputs.
+        Returns:
+            JitModelAnalysis : the new model analysis object
+        """
+        model = self._model if new_model is None else new_model
+        inputs = self._inputs if new_inputs is None else new_inputs
+        analyzer = copy(self)
+        analyzer.model = model
+        analyzer.inputs = inputs
+        return analyzer
+
+    def tracer_warnings(self, enabled: bool) -> None:
+        """
+        Sets if warnings from the jit tracing process are shown. Defaults
+        to True.
+
+        Args:
+            enabled (bool) : Set to 'True' to show tracer warnings
+        """
+        self.warn_trace = enabled
+
+    def skipped_ops_warnings(self, enabled: bool) -> None:
+        """
+        Sets if warnings from skipped operators are shown. Defaults
+        to True. Counts of skipped operators may be obtained from
+        .skipped_ops(module) regardless of this setting.
+
+        Args:
+            enabled (bool) : Set to 'True' to show skipped operator
+                warnings.
+        """
+        self.warn_skipped = enabled
+
+    @property
+    def model(self) -> nn.Module:
+        return self._model
+
+    @model.setter
+    def model(self, new_model: nn.Module) -> None:
+        self._model = new_model
+        self.counts = None
+
+    @property
+    def inputs(self) -> typing.Tuple[object, ...]:
+        return self._inputs
+
+    @inputs.setter
+    def inputs(self, new_inputs: typing.Tuple[object, ...]) -> None:
+        self._inputs = new_inputs
+        self.counts = None
+
+    @property
+    def ops_handles(self) -> typing.Dict[str, typing.Callable]:
+        return self.__ops_handles
+
+    @ops_handles.setter
+    def ops_handles(self, new_ops_handles: typing.Dict[str, typing.Callable]) -> None:
+        self._ops_handles = new_ops_handles
+        self.counts = None
+
+    def _rescale_count(self, count: int) -> float:
+        if self.scale == 1:
+            return count  # Maintain integer-valued counters
+        return count / self.scale
+
+    def _rescale_dict(self, count_dict: typing.Dict) -> typing.Dict:
+        scaled_dict = {k: self._rescale_count(count) for k, count in count_dict.items()}
+        if isinstance(count_dict, Counter):
+            scaled_dict = Counter(scaled_dict)
+        return scaled_dict
+
+    def _warn_skipped_ops(self, module: str or nn.Module) -> None:
+        if not self.warn_skipped:
+            return
+        logger = logging.getLogger(__name__)
+        skipped_ops = self._skipped_ops[module]
+        if len(skipped_ops) > 0:
+            for op, freq in skipped_ops.items():
+                logger.warning("Skipped operation {} {} time(s)".format(op, freq))
+
+    def _canonical_module_name(self, module: str or nn.Module) -> str:
+        if module in self.aliases:
+            return self.aliases[module]
+        return module
+
+    def _analyze(self) -> None:
+        # Don't calculate if results are already stored.
+        if self.counts is not None:
+            return
+
+        with warnings.catch_warnings():
+            if not self.warn_trace:
+                warnings.simplefilter("ignore")
+            graph, self.aliases = _get_scoped_trace_graph(self._model, self._inputs)
+
+        # Assures even modules not in the trace graph are initialized to zero count
+        counts = {}
+        skipped_ops = {}
+        for _, mod in self._model.named_modules():
+            name = self.aliases[mod]
+            counts[name] = Counter()
+            skipped_ops[name] = Counter()
+
+        for node in graph.nodes():
+            kind = node.kind()
+            scope_names = node.scopeName().split("/")
+            if kind not in self._ops_handles:
+                if kind in self.ignored_ops:
+                    continue
+
+                for name in scope_names:
+                    skipped_ops[name][kind] += 1
+            else:
+                inputs, outputs = list(node.inputs()), list(node.outputs())
+                op_counts = self._ops_handles[kind](inputs, outputs)
+
+                for name in scope_names:
+                    counts[name] += op_counts
+
+        self.counts = counts
+        self._skipped_ops = skipped_ops

--- a/fvcore/nn/jit_analysis.py
+++ b/fvcore/nn/jit_analysis.py
@@ -7,8 +7,8 @@ from typing import Any, Callable, Dict, Optional, Set, Tuple, Union
 
 import torch
 import torch.nn as nn
-from torch.jit import _get_trace_graph
 from fvcore.common.checkpoint import _named_modules_with_dup
+from torch.jit import _get_trace_graph
 
 
 _IGNORED_OPS: Set[str] = {
@@ -69,8 +69,8 @@ _IGNORED_OPS: Set[str] = {
 
 
 def _get_scoped_trace_graph(
-    module: nn.Module, 
-    inputs: Tuple[object, ...], 
+    module: nn.Module,
+    inputs: Tuple[object, ...],
     aliases: Dict[Union[str, nn.Module], str],
 ) -> typing.Tuple[torch._C.Graph, Dict[Union[str, nn.Module], str]]:
     """
@@ -84,7 +84,7 @@ def _get_scoped_trace_graph(
         model (nn.Module) : The module to trace
         inputs (tuple) : Inputs used during the trace of the model
         aliases (dict(str or nn.Module, str) : maps modules and module
-            names to the canonical name to be used as the scope for 
+            names to the canonical name to be used as the scope for
             that module.
 
     Returns:
@@ -130,7 +130,6 @@ def _get_scoped_trace_graph(
         hook_handles.append(prehook)
         hook_handles.append(posthook)
 
-
     # Torch script does not support parallel torch models, but we still
     # want the scope names to be correct for the complete module.
     if isinstance(
@@ -148,7 +147,6 @@ def _get_scoped_trace_graph(
             name = aliases[mod]
             register_hooks(mod, name)
             seen.add(mod)
-    
 
     if hasattr(torch.jit, "get_trace_graph"):
         trace, _ = torch.jit.get_trace_graph(module, inputs)
@@ -331,13 +329,10 @@ class JitModelAnalysis(object):
         model = self._model if new_model is None else new_model
         inputs = self._inputs if new_inputs is None else new_inputs
         analyzer = JitModelAnalysis(
-                model=model,
-                inputs=inputs,
-                ops_handles=self._ops_handles
+            model=model, inputs=inputs, ops_handles=self._ops_handles
         )
         analyzer.warn_skipped = self.warn_skipped
         analyzer.warn_trace = self.warn_trace
-
 
         return analyzer
 
@@ -376,7 +371,8 @@ class JitModelAnalysis(object):
         if module in self.aliases:
             return self.aliases[module]
         else:
-            raise KeyError("Requested module or module name is not among "
+            raise KeyError(
+                "Requested module or module name is not among "
                 "the descendants of the analyzed model."
             )
 
@@ -387,7 +383,6 @@ class JitModelAnalysis(object):
                 aliases[module] = name
             aliases[name] = aliases[module]
         return aliases
-
 
     def _analyze(self) -> None:
         # Don't calculate if results are already stored.

--- a/tests/test_activation_count.py
+++ b/tests/test_activation_count.py
@@ -4,11 +4,12 @@
 import typing
 import unittest
 from collections import Counter, defaultdict
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 import torch
 import torch.nn as nn
-from fvcore.nn.activation_count import Handle, activation_count
+from fvcore.nn.activation_count import activation_count, default_activation_counter
+from fvcore.nn.jit_handles import Handle
 from numpy import prod
 
 
@@ -33,15 +34,14 @@ class SmallConvNet(nn.Module):
         x = self.conv3(x)
         return x
 
-    def get_gt_activation(self, x: torch.Tensor) -> int:
-        count = 0
+    def get_gt_activation(self, x: torch.Tensor) -> Tuple[int, int, int]:
         x = self.conv1(x)
-        count += prod(list(x.size()))
+        count1 = prod(list(x.size()))
         x = self.conv2(x)
-        count += prod(list(x.size()))
+        count2 = prod(list(x.size()))
         x = self.conv3(x)
-        count += prod(list(x.size()))
-        return count
+        count3 = prod(list(x.size()))
+        return (count1, count2, count3)
 
 
 class TestActivationCount(unittest.TestCase):
@@ -59,7 +59,7 @@ class TestActivationCount(unittest.TestCase):
         x = torch.randn(batch_size, input_dim, spatial_dim, spatial_dim)
         convNet = SmallConvNet(input_dim)
         ac_dict, _ = activation_count(convNet, (x,))
-        gt_count = convNet.get_gt_activation(x)
+        gt_count = sum(convNet.get_gt_activation(x))
 
         gt_dict = defaultdict(float)
         gt_dict["conv"] = gt_count / 1e6
@@ -107,5 +107,51 @@ class TestActivationCount(unittest.TestCase):
         self.assertDictEqual(
             gt_dict,
             ac_dict,
+            "ConvNet with 3 layers failed to pass the activation count test.",
+        )
+
+    def test_default_activation_counter(self) -> None:
+        """
+        Test that the default activation counter returns the expected flops
+        in the expected scale.
+        """
+        batch_size = 1
+        input_dim = 10
+        output_dim = 20
+        netLinear = nn.Linear(input_dim, output_dim)
+        x = torch.randn(batch_size, input_dim)
+        gt_count = batch_size * output_dim / 1e6
+        gt_dict = Counter(
+            {
+                "": gt_count,
+            }
+        )
+        acts_counter = default_activation_counter(netLinear, (x,))
+        self.assertEqual(
+            acts_counter.by_module(),
+            gt_dict,
+            "default_activation_counter is not producing an analyzer "
+            "with the correct properties for a linear net.",
+        )
+
+        batch_size = 1
+        input_dim = 3
+        spatial_dim = 32
+        x = torch.randn(batch_size, input_dim, spatial_dim, spatial_dim)
+        convNet = SmallConvNet(input_dim)
+        acts_counter = default_activation_counter(convNet, (x,))
+        gt_counts = convNet.get_gt_activation(x)
+        gt_dict = Counter(
+            {
+                "": sum(gt_counts) / 1e6,
+                "conv1": gt_counts[0] / 1e6,
+                "conv2": gt_counts[1] / 1e6,
+                "conv3": gt_counts[2] / 1e6,
+            }
+        )
+
+        self.assertDictEqual(
+            gt_dict,
+            acts_counter.by_module(),
             "ConvNet with 3 layers failed to pass the activation count test.",
         )

--- a/tests/test_activation_count.py
+++ b/tests/test_activation_count.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Tuple
 
 import torch
 import torch.nn as nn
-from fvcore.nn.activation_count import activation_count, ActivationCount
+from fvcore.nn.activation_count import ActivationCount, activation_count
 from fvcore.nn.jit_handles import Handle
 from numpy import prod
 

--- a/tests/test_jit_model_analysis.py
+++ b/tests/test_jit_model_analysis.py
@@ -303,13 +303,6 @@ class TestJitModelAnalysis(unittest.TestCase):
                 gt_flops = sum(model.flops[name].values())
                 self.assertEqual(analyzer.total(name), gt_flops)
 
-        # Using a module input
-        for name in model.flops:
-            with self.subTest(name=name):
-                mod = model.name_to_module[name]
-                gt_flops = sum(model.flops[name].values())
-                self.assertEqual(analyzer.total(mod), gt_flops)
-
     def test_by_module(self) -> None:
         """
         Tests that JitModelAnalysis.by_module() returns the correct
@@ -342,12 +335,6 @@ class TestJitModelAnalysis(unittest.TestCase):
         for name in model.flops:
             with self.subTest(name=name):
                 self.assertEqual(analyzer.by_operator(name), model.flops[name])
-
-        # Using a module input
-        for name in model.flops:
-            with self.subTest(name=name):
-                mod = model.name_to_module[name]
-                self.assertEqual(analyzer.by_operator(mod), model.flops[name])
 
     def test_by_module_and_operator(self) -> None:
         """
@@ -469,34 +456,18 @@ class TestJitModelAnalysis(unittest.TestCase):
             flops["submod1.submod"],
         )
         self.assertEqual(
-            analyzer.total(model.submod2.submod),
-            flops["submod1.submod"],
-        )
-        self.assertEqual(
             analyzer.total("multiname2"),
-            flops["multiname1"],
-        )
-        self.assertEqual(
-            analyzer.total(model.multiname2),
             flops["multiname1"],
         )
 
         # Test getting canonical name
         self.assertEqual(analyzer.canonical_module_name("multiname2"), "multiname1")
         self.assertEqual(analyzer.canonical_module_name("multiname1"), "multiname1")
-        self.assertEqual(analyzer.canonical_module_name(model.multiname2), "multiname1")
-        self.assertEqual(analyzer.canonical_module_name(model.multiname1), "multiname1")
         self.assertEqual(
             analyzer.canonical_module_name("submod2.submod"), "submod1.submod"
         )
         self.assertEqual(
             analyzer.canonical_module_name("submod1.submod"), "submod1.submod"
-        )
-        self.assertEqual(
-            analyzer.canonical_module_name(model.submod2.submod), "submod1.submod"
-        )
-        self.assertEqual(
-            analyzer.canonical_module_name(model.submod1.submod), "submod1.submod"
         )
 
     def test_data_parallel(self) -> None:
@@ -528,13 +499,6 @@ class TestJitModelAnalysis(unittest.TestCase):
             with self.subTest(name=name):
                 gt_flops = sum(flops[name].values())
                 self.assertEqual(analyzer.total(name), gt_flops)
-
-        # Using a module input
-        for name in flops:
-            with self.subTest(name=name):
-                mod = name_to_module[name]
-                gt_flops = sum(flops[name].values())
-                self.assertEqual(analyzer.total(mod), gt_flops)
 
         # Output as dictionary
         self.assertEqual(analyzer.by_module_and_operator(), flops)
@@ -578,12 +542,6 @@ class TestJitModelAnalysis(unittest.TestCase):
         for name in skipped:
             with self.subTest(name=name):
                 self.assertEqual(analyzer.skipped_ops(name), skipped[name])
-
-        # Access by module
-        for name in skipped:
-            with self.subTest(name=name):
-                mod = model.name_to_module[name]
-                self.assertEqual(analyzer.skipped_ops(mod), skipped[name])
 
     def test_changing_handles(self) -> None:
         """

--- a/tests/test_jit_model_analysis.py
+++ b/tests/test_jit_model_analysis.py
@@ -1,0 +1,1150 @@
+import logging
+import typing
+import unittest
+import warnings
+from collections import Counter
+from io import StringIO
+from typing import Any, Dict, List
+
+import torch
+import torch.nn as nn
+from fvcore.nn.jit_analysis import JitModelAnalysis
+from fvcore.nn.jit_handles import Handle, addmm_flop_jit, conv_flop_jit
+
+
+class NestedNetInnerModule(nn.Module):
+    """
+    A submodule for the nested net test module below.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        conv_input_size = (2, 5)
+        conv_in = 2
+        conv_out = 2
+        kernel_size = 1
+        padding = 0
+        fc_in = 10
+        fc_out = 10
+
+        self.conv = nn.Conv1d(
+            in_channels=conv_in,
+            out_channels=conv_out,
+            kernel_size=kernel_size,
+            padding=padding,
+        )
+        self.fc = nn.Linear(in_features=fc_in, out_features=fc_out)
+
+        self.fc_flops = fc_in * fc_out
+        spatial_pos = (conv_input_size[1] + 2 * padding) - 2 * (kernel_size // 2)
+        self.conv_flops = spatial_pos * kernel_size * conv_in * conv_out
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x.reshape(-1, 2, 5)
+        x = self.conv(x)
+        x = torch.flatten(x, 1)
+        x = 3 * self.fc(x) + 1
+        return x
+
+
+class NestedNet(nn.Module):
+    """
+    A network with nested submodules for testing the ability to correctly
+    capture scope information.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.input_size = (4, 5)
+
+        conv_in = 4
+        conv_out = 4
+        kernel_size = 3
+        padding = 1
+        fc_in = 20
+        fc_out = 10
+
+        self.submod = NestedNetInnerModule()
+        self.fc = nn.Linear(in_features=fc_in, out_features=fc_out)
+        self.conv = nn.Conv1d(
+            in_channels=conv_in,
+            out_channels=conv_out,
+            kernel_size=kernel_size,
+            padding=padding,
+        )
+
+        self.fc_flops = fc_in * fc_out
+        spatial_pos = (self.input_size[1] + 2 * padding) - 2 * (kernel_size // 2)
+        self.conv_flops = spatial_pos * kernel_size * conv_in * conv_out
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv(x)
+        x = torch.flatten(x, 1)
+        x = self.fc(x)
+        x = self.submod(x) ** 2
+        return x
+
+
+class UnusedNet(nn.Module):
+    """
+    Has a submodule that is never called in the forward function.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.input_size = (10,)
+        fc1_in, fc1_out = 10, 10
+        fc2_in, fc2_out = 10, 1
+        unused_in, unused_out = 20, 20
+
+        self.fc1 = nn.Linear(in_features=fc1_in, out_features=fc1_out)
+        self.fc2 = nn.Linear(in_features=fc2_in, out_features=fc2_out)
+        self.unused = nn.Linear(in_features=unused_in, out_features=unused_out)
+
+        self.fc1_flops = fc1_in * fc1_out
+        self.fc2_flops = fc2_in * fc2_out
+        self.unused_flops = unused_in * unused_out  # If it were applied
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.fc1(x))
+
+
+class RepeatedNet(nn.Module):
+    """
+    Makes repeated calls to the same submodule.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.input_size = (10,)
+        fc1_in, fc1_out = 10, 10
+        fc2_in, fc2_out = 10, 10
+        self.fc1_num = 3
+        self.fc2_num = 2
+
+        self.fc1 = nn.Linear(in_features=fc1_in, out_features=fc1_out)
+        self.fc2 = nn.Linear(in_features=fc2_in, out_features=fc2_out)
+
+        self.fc1_flops = fc1_in * fc1_out
+        self.fc2_flops = fc2_in * fc2_out
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for i in range(self.fc1_num):
+            x = self.fc1(x)
+        for i in range(self.fc2_num):
+            x = self.fc2(x)
+        return x
+
+
+class NonForwardInnerModule(nn.Module):
+    """
+    Has a function separate from the forward function.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.input_size = (10,)
+        fc_in, fc_out = 10, 1
+
+        self.fc = nn.Linear(in_features=fc_in, out_features=fc_out)
+
+        self.fc_flops = fc_in * fc_out
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x
+
+    def other_func(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc(x)
+
+
+class NonForwardNet(nn.Module):
+    """
+    The submodule has a non-forward function called by the parent module.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.input_size = (10,)
+        fc_in, fc_out = 10, 10
+
+        self.submod = NonForwardInnerModule()
+        self.fc = nn.Linear(in_features=fc_in, out_features=fc_out)
+
+        self.fc_flops = fc_in * fc_out
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.submod.other_func(self.fc(x))
+
+
+class SharingInnerModule(nn.Module):
+    """
+    Is initialized with a module that it may share with other modules.
+    """
+
+    def __init__(self, submod: nn.Module) -> None:
+        super().__init__()
+        self.submod = submod
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.submod(x)
+
+
+class SharedModuleNet(nn.Module):
+    """
+    A subsubmodule is shared by multiple submodules. Also calls a module
+    using multiple names.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.input_size = (10,)
+        fc1_in, fc1_out = 10, 10
+        fc2_in, fc2_out = 10, 1
+
+        inner = nn.Linear(in_features=fc1_in, out_features=fc1_out)
+        self.submod1 = SharingInnerModule(inner)
+        self.submod2 = SharingInnerModule(inner)
+        multiname = nn.Linear(in_features=fc2_in, out_features=fc2_out)
+        # multiname2 will not appear in module.named_children()
+        self.multiname1 = multiname
+        self.multiname2 = multiname
+
+        self.multiname_flops = fc2_in * fc2_out
+        self.shared_flops = fc1_in * fc1_out
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.submod1(x) + self.submod2(x)
+        x = self.multiname1(x) + self.multiname2(x)
+        return x
+
+
+class TraceWarningNet(nn.Module):
+    """
+    Will raise a warning on trace due to python comparison of tensor data.
+    Also has an aten::add op that will be skipped and raise a warning.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.input_size = (10,)
+        fc1_in, fc1_out = 10, 1
+        fc2_in, fc2_out = 10, 10
+
+        self.fc1 = nn.Linear(in_features=fc1_in, out_features=fc1_out)
+        self.fc2 = nn.Linear(in_features=fc2_in, out_features=fc2_out)
+
+        self.fc1_flops = fc1_in, fc1_out
+        self.fc2_flops = fc2_in, fc2_out
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        y = self.fc1(x).item()
+        if y < 0.0:
+            x = self.fc2(x)
+        return x + 2
+
+
+class TestJitModelAnalysis(unittest.TestCase):
+    """
+    Unittest for JitModelAnalysis. Tests for specific jit_handles are
+    covered in test_flop_count.py and test_activation_count.py.
+    """
+
+    def test_total(self) -> None:
+        """
+        Tests that JitModelAnalysis.total(module) returns the correct
+        counts for string and module inputs.
+        """
+
+        model = NestedNet()
+        inputs = (torch.randn((1, *model.input_size)),)
+        ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+            "aten::_convolution": conv_flop_jit,
+        }
+
+        analyzer = JitModelAnalysis(model=model, inputs=inputs, ops_handles=ops_handles)
+        analyzer.skipped_ops_warnings(enabled=False)
+
+        submod_flops = model.submod.fc_flops + model.submod.conv_flops
+        model_flops = model.conv_flops + model.fc_flops + submod_flops
+        flops = {
+            "": model_flops,
+            "fc": model.fc_flops,
+            "conv": model.conv_flops,
+            "submod": submod_flops,
+            "submod.fc": model.submod.fc_flops,
+            "submod.conv": model.submod.conv_flops,
+        }
+
+        name_to_module = {
+            "": model,
+            "fc": model.fc,
+            "conv": model.conv,
+            "submod": model.submod,
+            "submod.fc": model.submod.fc,
+            "submod.conv": model.submod.conv,
+        }
+
+        # Using a string input
+        for name in flops:
+            with self.subTest(name=name):
+                self.assertEqual(
+                    analyzer.total(name),
+                    flops[name],
+                    ".total(...) failed count test for input string.",
+                )
+
+        # Using a module input
+        for name in flops:
+            with self.subTest(name=name):
+                mod = name_to_module[name]
+                self.assertEqual(
+                    analyzer.total(mod),
+                    flops[name],
+                    ".total(...) failed count test for input module.",
+                )
+
+    def test_by_module(self) -> None:
+        """
+        Tests that JitModelAnalysis.by_module() returns the correct
+        counts in the correctly structured dictionary.
+        """
+
+        model = NestedNet()
+        inputs = (torch.randn((1, *model.input_size)),)
+        ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+            "aten::_convolution": conv_flop_jit,
+        }
+
+        analyzer = JitModelAnalysis(model=model, inputs=inputs, ops_handles=ops_handles)
+        analyzer.skipped_ops_warnings(enabled=False)
+
+        submod_flops = model.submod.fc_flops + model.submod.conv_flops
+        model_flops = model.conv_flops + model.fc_flops + submod_flops
+        flops = {
+            "": model_flops,
+            "fc": model.fc_flops,
+            "conv": model.conv_flops,
+            "submod": submod_flops,
+            "submod.fc": model.submod.fc_flops,
+            "submod.conv": model.submod.conv_flops,
+        }
+
+        self.assertEqual(analyzer.by_module(), flops, ".by_module() failed count test.")
+
+    def test_by_operator(self) -> None:
+        """
+        Tests that JitModelAnalysis.by_operator(module) returns the correct
+        counts for string and module inputs.
+        """
+
+        model = NestedNet()
+        inputs = (torch.randn((1, *model.input_size)),)
+        ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+            "aten::_convolution": conv_flop_jit,
+        }
+
+        analyzer = JitModelAnalysis(model=model, inputs=inputs, ops_handles=ops_handles)
+        analyzer.skipped_ops_warnings(enabled=False)
+
+        submod_conv_flops = Counter({"conv": model.submod.conv_flops})
+        submod_fc_flops = Counter({"addmm": model.submod.fc_flops})
+        submod_flops = submod_conv_flops + submod_fc_flops
+        conv_flops = Counter({"conv": model.conv_flops})
+        fc_flops = Counter({"addmm": model.fc_flops})
+        model_flops = submod_flops + conv_flops + fc_flops
+        flops = {
+            "": model_flops,
+            "fc": fc_flops,
+            "conv": conv_flops,
+            "submod": submod_flops,
+            "submod.fc": submod_fc_flops,
+            "submod.conv": submod_conv_flops,
+        }
+
+        name_to_module = {
+            "": model,
+            "fc": model.fc,
+            "conv": model.conv,
+            "submod": model.submod,
+            "submod.fc": model.submod.fc,
+            "submod.conv": model.submod.conv,
+        }
+
+        # Using a string input
+        for name in flops:
+            with self.subTest(name=name):
+                self.assertEqual(
+                    analyzer.by_operator(name),
+                    flops[name],
+                    ".total(...) failed count test for input string.",
+                )
+
+        # Using a module input
+        for name in flops:
+            with self.subTest(name=name):
+                mod = name_to_module[name]
+                self.assertEqual(
+                    analyzer.by_operator(mod),
+                    flops[name],
+                    ".total(...) failed count test for input module.",
+                )
+
+    def test_by_module_and_operator(self) -> None:
+        """
+        Tests that JitModelAnalysis.by_module_and_operator() returns
+        the correct counts in the correct structure.
+        """
+
+        model = NestedNet()
+        inputs = (torch.randn((1, *model.input_size)),)
+        ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+            "aten::_convolution": conv_flop_jit,
+        }
+
+        analyzer = JitModelAnalysis(model=model, inputs=inputs, ops_handles=ops_handles)
+        analyzer.skipped_ops_warnings(enabled=False)
+
+        submod_conv_flops = Counter({"conv": model.submod.conv_flops})
+        submod_fc_flops = Counter({"addmm": model.submod.fc_flops})
+        submod_flops = submod_conv_flops + submod_fc_flops
+        conv_flops = Counter({"conv": model.conv_flops})
+        fc_flops = Counter({"addmm": model.fc_flops})
+        model_flops = submod_flops + conv_flops + fc_flops
+        flops = {
+            "": model_flops,
+            "fc": fc_flops,
+            "conv": conv_flops,
+            "submod": submod_flops,
+            "submod.fc": submod_fc_flops,
+            "submod.conv": submod_conv_flops,
+        }
+
+        self.assertEqual(
+            analyzer.by_module_and_operator(), flops, ".by_module() failed count test."
+        )
+
+    def test_unused_module(self) -> None:
+        """
+        Tests that unused modules return 0 count for operator sums and
+        and empty Counter() for per-operator results.
+        """
+
+        model = UnusedNet()
+        inputs = (torch.randn((1, *model.input_size)),)
+        ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+        }
+
+        analyzer = JitModelAnalysis(model=model, inputs=inputs, ops_handles=ops_handles)
+
+        unused_count = 0
+        unused_per_operator = Counter()
+        model_count = model.fc1_flops + model.fc2_flops
+
+        self.assertEqual(
+            analyzer.total("unused"),
+            unused_count,
+            "Unused module failed to result in .total(unused)=0.",
+        )
+
+        self.assertEqual(
+            analyzer.by_operator("unused"),
+            unused_per_operator,
+            "Unused module failed to result in .by_operator(unused)=Counter().",
+        )
+
+        self.assertEqual(
+            analyzer.total(""),
+            model_count,
+            "Unused module caused parent to return incorrect total count.",
+        )
+
+    def test_repeated_module(self) -> None:
+        """
+        Tests that repeated calls to the same submodule correct aggregates
+        results to that submodule.
+        """
+
+        model = RepeatedNet()
+        inputs = (torch.randn((1, *model.input_size)),)
+        ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+        }
+
+        analyzer = JitModelAnalysis(model=model, inputs=inputs, ops_handles=ops_handles)
+
+        fc1_count = model.fc1_num * model.fc1_flops
+        fc2_count = model.fc2_num * model.fc2_flops
+        total_count = fc1_count + fc2_count
+        fc1_per_operator = Counter({"addmm": fc1_count})
+
+        self.assertEqual(
+            analyzer.total("fc1"),
+            fc1_count,
+            ".total() failed to aggregate counts over repeated module calls.",
+        )
+
+        self.assertEqual(
+            analyzer.total("fc2"),
+            fc2_count,
+            ".total() failed to aggregate counts over repeated module calls.",
+        )
+
+        self.assertEqual(
+            analyzer.total(""),
+            total_count,
+            "Repeated submodule calls caused incorrect count in parent.",
+        )
+
+        self.assertEqual(
+            analyzer.by_operator("fc1"),
+            fc1_per_operator,
+            ".by_operator() failed to aggregate counts over repeated module calls.",
+        )
+
+    def test_non_forward_func_call(self) -> None:
+        """
+        Tests that calls to a submodule's non-forward function attribute
+        resulting counts to the calling module.
+        """
+
+        model = NonForwardNet()
+        inputs = (torch.randn((1, 10)),)
+        ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+        }
+
+        analyzer = JitModelAnalysis(model=model, inputs=inputs, ops_handles=ops_handles)
+
+        submod_count = 0
+        inner_fc_count = model.submod.fc_flops
+        total_count = model.fc_flops + inner_fc_count
+
+        self.assertEqual(
+            analyzer.total("submod"),
+            submod_count,
+            ".total('submod') fails to give 0 count.",
+        )
+
+        self.assertEqual(
+            analyzer.total("submod.fc"),
+            inner_fc_count,
+            ".total('submod.fc') fails to give the correct count.",
+        )
+
+        self.assertEqual(
+            analyzer.total(""),
+            total_count,
+            ".total('') fails to give the correct count.",
+        )
+
+    def test_shared_module(self) -> None:
+        """
+        Tests the behavior of shared submodules that may have multiple
+        names.
+        """
+
+        model = SharedModuleNet()
+        inputs = (torch.randn((1, *model.input_size)),)
+        ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+        }
+
+        analyzer = JitModelAnalysis(model=model, inputs=inputs, ops_handles=ops_handles)
+        analyzer.skipped_ops_warnings(enabled=False)
+
+        # The names `submod2.submod` and `multiname2` are not included,
+        # since only the first name of a module is made the canonical one.
+        # The counts associated with these cases are included under
+        # `submod1.submod` and `multiname1` respectively.
+        multiname_flops = 2 * model.multiname_flops  # Called under 2 names
+        shared_flops = 2 * model.shared_flops  # Shared under 2 submodules
+        total_flops = multiname_flops + shared_flops
+        flops = {
+            "": total_flops,
+            "submod1": model.shared_flops,
+            "submod1.submod": shared_flops,
+            "submod2": model.shared_flops,
+            "multiname1": multiname_flops,
+        }
+
+        self.assertEqual(
+            analyzer.by_module(),
+            flops,
+            ".by_module() failed to give the expected names for shared modules.",
+        )
+
+        # Test access by alternative name
+        self.assertEqual(
+            analyzer.total("submod2.submod"),
+            flops["submod1.submod"],
+            ".total(...) fails to return correct result for alternative name "
+            "of shared module.",
+        )
+
+        self.assertEqual(
+            analyzer.total(model.submod2.submod),
+            flops["submod1.submod"],
+            ".total(...) fails to return correct result for alternative name "
+            "of shared module.",
+        )
+
+        # multiname2 is not a valid name since it is never encountered
+        # in .named_children() or .named_modules(), so the analysis
+        # doesn't know anything about it. Access using the model's
+        # attribute should still work though:
+        self.assertEqual(
+            analyzer.total(model.multiname2),
+            flops["multiname1"],
+            ".total(...) fails to return correct result for alternative name "
+            "of submodule with multiple names.",
+        )
+
+    def test_data_parallel(self) -> None:
+        """
+        Tests that a model wrapped in DataParallel still returns results
+        labelled by the correct scopes.
+        """
+        model = NestedNet()
+        inputs = (torch.randn((1, *model.input_size)),)
+        ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+            "aten::_convolution": conv_flop_jit,
+        }
+
+        submod_flops = model.submod.fc_flops + model.submod.conv_flops
+        model_flops = model.conv_flops + model.fc_flops + submod_flops
+        flops = {
+            "": model_flops,
+            "module": model_flops,
+            "module.fc": model.fc_flops,
+            "module.conv": model.conv_flops,
+            "module.submod": submod_flops,
+            "module.submod.fc": model.submod.fc_flops,
+            "module.submod.conv": model.submod.conv_flops,
+        }
+
+        model = torch.nn.DataParallel(model)
+        analyzer = JitModelAnalysis(model=model, inputs=inputs, ops_handles=ops_handles)
+        analyzer.skipped_ops_warnings(enabled=False)
+
+        name_to_module = {
+            "": model,
+            "module": model.module,
+            "module.fc": model.module.fc,
+            "module.conv": model.module.conv,
+            "module.submod": model.module.submod,
+            "module.submod.fc": model.module.submod.fc,
+            "module.submod.conv": model.module.submod.conv,
+        }
+
+        # Using a string input
+        for name in flops:
+            with self.subTest(name=name):
+                self.assertEqual(
+                    analyzer.total(name),
+                    flops[name],
+                    ".total(...) failed for DataParallel model for input string.",
+                )
+
+        # Using a module input
+        for name in flops:
+            with self.subTest(name=name):
+                mod = name_to_module[name]
+                self.assertEqual(
+                    analyzer.total(mod),
+                    flops[name],
+                    ".total(...) failed for DataParallel model for input module.",
+                )
+
+        # Output as dictionary
+        self.assertEqual(
+            analyzer.by_module(), flops, ".by_module() failed for DataParallel model."
+        )
+
+    def test_skipped_ops(self) -> None:
+        """
+        Tests per-module recording of skipped operations.
+        """
+
+        model = NestedNet()
+        inputs = (torch.randn((1, *model.input_size)),)
+        ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+        }
+
+        analyzer = JitModelAnalysis(model=model, inputs=inputs, ops_handles=ops_handles)
+
+        skipped_inner_conv = Counter({"aten::_convolution": 1})
+        skipped_inner_fc = Counter()
+        skipped_inner = Counter({"aten::add": 1, "aten::mul": 1})
+        skipped_inner += skipped_inner_fc
+        skipped_inner += skipped_inner_conv
+
+        skipped_outer_conv = Counter({"aten::_convolution": 1})
+        skipped_outer_fc = Counter()
+        skipped_outer = Counter({"aten::pow": 1})
+        skipped_outer += skipped_outer_conv
+        skipped_outer += skipped_outer_fc
+        skipped_outer += skipped_inner
+
+        skipped = {
+            "": skipped_outer,
+            "conv": skipped_outer_conv,
+            "fc": skipped_outer_fc,
+            "submod": skipped_inner,
+            "submod.conv": skipped_inner_conv,
+            "submod.fc": skipped_inner_fc,
+        }
+
+        name_to_module = {
+            "": model,
+            "fc": model.fc,
+            "conv": model.conv,
+            "submod": model.submod,
+            "submod.fc": model.submod.fc,
+            "submod.conv": model.submod.conv,
+        }
+
+        # Access by string
+        for name in skipped:
+            with self.subTest(name=name):
+                self.assertEqual(
+                    analyzer.skipped_ops(name),
+                    skipped[name],
+                    ".skipped_ops(...) failed count test for input module.",
+                )
+
+        # Access by module
+        for name in skipped:
+            with self.subTest(name=name):
+                mod = name_to_module[name]
+                self.assertEqual(
+                    analyzer.skipped_ops(mod),
+                    skipped[name],
+                    ".skipped_ops(...) failed count test for input module.",
+                )
+
+    def test_changing_handles(self) -> None:
+        """
+        Tests .set_ops_handle(), .clear_ops_handles(), and modifying
+        .ops_handles directly.
+        """
+        model = NestedNet()
+        inputs = (torch.randn((1, *model.input_size)),)
+        ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+        }
+
+        analyzer = JitModelAnalysis(model=model, inputs=inputs, ops_handles=ops_handles)
+        analyzer.skipped_ops_warnings(enabled=False)
+
+        # Request a result once to cache flop counts
+        _ = analyzer.total("")
+
+        # Add an op handle
+        analyzer.set_ops_handle("aten::_convolution", conv_flop_jit)
+
+        submod_conv_flops = Counter({"conv": model.submod.conv_flops})
+        submod_fc_flops = Counter({"addmm": model.submod.fc_flops})
+        submod_flops = submod_conv_flops + submod_fc_flops
+        conv_flops = Counter({"conv": model.conv_flops})
+        fc_flops = Counter({"addmm": model.fc_flops})
+        model_flops = submod_flops + conv_flops + fc_flops
+        flops = {
+            "": model_flops,
+            "fc": fc_flops,
+            "conv": conv_flops,
+            "submod": submod_flops,
+            "submod.fc": submod_fc_flops,
+            "submod.conv": submod_conv_flops,
+        }
+
+        self.assertEqual(
+            analyzer.by_module_and_operator(),
+            flops,
+            ".by_module_and_operator() failed count test when a handle was added.",
+        )
+
+        # Overwrite an op handle
+        def make_dummy_op(output: int) -> Handle:
+            def dummy_ops_handle(
+                inputs: List[Any], outputs: List[Any]
+            ) -> typing.Counter:
+                return Counter({"dummy_op": output})
+
+            return dummy_ops_handle
+
+        dummy_out = 1000
+        analyzer.set_ops_handle("aten::addmm", make_dummy_op(dummy_out))
+
+        submod_conv_flops = Counter({"conv": model.submod.conv_flops})
+        submod_fc_flops = Counter({"dummy_op": dummy_out})
+        submod_flops = submod_conv_flops + submod_fc_flops
+        conv_flops = Counter({"conv": model.conv_flops})
+        fc_flops = Counter({"dummy_op": dummy_out})
+        model_flops = submod_flops + conv_flops + fc_flops
+        dummy_flops = {
+            "": Counter({"dummy_op": 2000, "conv": 260}),
+            "fc": Counter({"dummy_op": 1000}),
+            "conv": Counter({"conv": 240}),
+            "submod": Counter({"dummy_op": 1000, "conv": 20}),
+            "submod.fc": Counter({"dummy_op": 1000}),
+            "submod.conv": Counter({"conv": 20}),
+        }
+
+        self.assertEqual(
+            analyzer.by_module_and_operator(),
+            dummy_flops,
+            ".by_module_and_operator() failed count test when a handle"
+            " was overwritten.",
+        )
+
+        # Clear ops handles
+        analyzer.clear_ops_handles()
+
+        empty_flops = {
+            "": Counter(),
+            "fc": Counter(),
+            "conv": Counter(),
+            "submod": Counter(),
+            "submod.fc": Counter(),
+            "submod.conv": Counter(),
+        }
+
+        self.assertEqual(
+            analyzer.by_module_and_operator(),
+            empty_flops,
+            ".by_module_and_operator() failed count test when handles"
+            " were cleared with .clear_ops_handles().",
+        )
+
+        # Directly write to JitModelAnalysis ops_handles property
+        analyzer.ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+            "aten::_convolution": conv_flop_jit,
+        }
+
+        self.assertEqual(
+            analyzer.by_module_and_operator(),
+            flops,
+            ".by_module_and_operator() failed count test when handles"
+            " were set directly.",
+        )
+
+    def test_changing_model_and_inputs(self) -> None:
+        """
+        Tests direct changes to the .model and .inputs properties of
+        JitModelAnalysis.
+        """
+        model = RepeatedNet()
+        inputs = (torch.randn((1, *model.input_size)),)
+        ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+        }
+
+        analyzer = JitModelAnalysis(model=model, inputs=inputs, ops_handles=ops_handles)
+
+        repeated_net_flops = model.fc1_num * model.fc1_flops
+        repeated_net_flops += model.fc2_num * model.fc2_flops
+
+        # Request once to cache results
+        _ = analyzer.total()
+
+        # Change model
+        new_model = NonForwardNet()
+        self.assertEqual(
+            new_model.input_size,
+            model.input_size,
+            "Test failed to be consistent; to test model change valid "
+            "input sizes need to be the same for the two models.",
+        )
+
+        analyzer.model = new_model
+
+        non_forward_flops = new_model.fc_flops + new_model.submod.fc_flops
+
+        self.assertEqual(
+            analyzer.total(),
+            non_forward_flops,
+            ".total() returned incorrect count after model was changed.",
+        )
+
+        # Change the inputs
+        bs = 5
+        analyzer.inputs = (torch.randn((bs, *new_model.input_size)),)
+
+        self.assertEqual(
+            analyzer.total(),
+            non_forward_flops * bs,
+            ".total() returned incorrect count after inputs were changed.",
+        )
+
+    def test_output_scale(self) -> None:
+        """
+        Tests .set_output_scale(...) and .get_output_scale().
+        """
+
+        model = NestedNet()
+        inputs = (torch.randn((1, *model.input_size)),)
+        ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+            "aten::_convolution": conv_flop_jit,
+        }
+
+        analyzer = JitModelAnalysis(model=model, inputs=inputs, ops_handles=ops_handles)
+        analyzer.skipped_ops_warnings(enabled=False)
+        analyzer.set_output_scale(scale="kilo")
+
+        def rescale(counter: Dict[str, int], x: int) -> Dict[str, float]:
+            out_dict = {k: v / x for k, v in counter.items()}
+            if isinstance(counter, Counter):
+                out_dict = Counter(out_dict)
+            return out_dict
+
+        submod_conv_flops = Counter({"conv": model.submod.conv_flops})
+        submod_fc_flops = Counter({"addmm": model.submod.fc_flops})
+        submod_flops = submod_conv_flops + submod_fc_flops
+        conv_flops = Counter({"conv": model.conv_flops})
+        fc_flops = Counter({"addmm": model.fc_flops})
+        model_flops = submod_flops + conv_flops + fc_flops
+        flops = {
+            "": rescale(model_flops, 1e3),
+            "fc": rescale(fc_flops, 1e3),
+            "conv": rescale(conv_flops, 1e3),
+            "submod": rescale(submod_flops, 1e3),
+            "submod.fc": rescale(submod_fc_flops, 1e3),
+            "submod.conv": rescale(submod_conv_flops, 1e3),
+        }
+
+        # Test rescaling in .by_module_and_operator()
+        self.assertEqual(
+            analyzer.by_module_and_operator(),
+            flops,
+            "Incorrect results for fractional counter values when outputting "
+            "at non-unity scale in .by_module_and_operator().",
+        )
+
+        # Test rescaling in .by_operator()
+        self.assertEqual(
+            analyzer.by_operator(""),
+            flops[""],
+            "Incorrect results for fractional counter values when outputting "
+            "at non-unity scale in .by_operator().",
+        )
+
+        submod_flops = model.submod.fc_flops + model.submod.conv_flops
+        model_flops = model.conv_flops + model.fc_flops + submod_flops
+        flops = {
+            "": model_flops,
+            "fc": model.fc_flops,
+            "conv": model.conv_flops,
+            "submod": submod_flops,
+            "submod.fc": model.submod.fc_flops,
+            "submod.conv": model.submod.conv_flops,
+        }
+        flops = rescale(flops, 1e3)
+
+        # Test rescaling in .by_module()
+        self.assertEqual(
+            analyzer.by_module(),
+            flops,
+            "Incorrect results for fractional counter values when outputting "
+            "at non-unity scale in .by_module().",
+        )
+
+        # Test rescaling in .total()
+        self.assertEqual(
+            analyzer.total(""),
+            flops[""],
+            "Incorrect results for fractional counter values when outputting "
+            "at non-unity scale in .by_module().",
+        )
+
+        # Test named scales
+        named_scales = {
+            "unity": 1,
+            "kilo": 1e3,
+            "mega": 1e6,
+            "giga": 1e9,
+            "tera": 1e12,
+            "peta": 1e15,
+        }
+
+        for name, scale in named_scales.items():
+            with self.subTest(name=name):
+                analyzer.set_output_scale(name)
+                self.assertEqual(
+                    analyzer.total(),
+                    model_flops / scale,
+                    ".total() returned incorrect count for scale {}".format(name),
+                )
+                self.assertEqual(
+                    analyzer.get_output_scale(),
+                    scale,
+                    ".get_output_scale() returned the wrong scale.",
+                )
+
+        # Test explicit numeric scale
+        test_scale = 2500
+        analyzer.set_output_scale(test_scale)
+        self.assertEqual(
+            analyzer.total(),
+            model_flops / test_scale,
+            ".total() returned incorrect results for numerical scale.",
+        )
+        self.assertEqual(
+            analyzer.get_output_scale(),
+            test_scale,
+            ".get_output_scale() returned the wrong scale.",
+        )
+
+    def test_copy(self) -> None:
+        """
+        Tests .copy(...)
+        """
+
+        model = RepeatedNet()
+        inputs = (torch.randn((1, *model.input_size)),)
+        ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+        }
+
+        analyzer = JitModelAnalysis(model=model, inputs=inputs, ops_handles=ops_handles)
+        analyzer.set_output_scale("giga")
+        analyzer.skipped_ops_warnings(enabled=False)
+        analyzer.tracer_warnings(enabled=False)
+
+        repeated_net_flops = model.fc1_num * model.fc1_flops
+        repeated_net_flops += model.fc2_num * model.fc2_flops
+
+        analyzer_copy = analyzer.copy()
+
+        # Outputs are the same
+        self.assertEqual(
+            analyzer.by_module_and_operator(),
+            analyzer_copy.by_module_and_operator(),
+            ".copy() gives JitModelAnalysis with different results than.",
+        )
+
+        # Settings match
+        self.assertEqual(
+            analyzer.warn_skipped,
+            analyzer_copy.warn_skipped,
+            ".copy() gives JitModelAnalysis with different warning settings.",
+        )
+
+        self.assertEqual(
+            analyzer.warn_trace,
+            analyzer_copy.warn_trace,
+            ".copy() gives JitModelAnalysis with different warning settings.",
+        )
+
+        # Changing copy does not change original
+        analyzer_copy.skipped_ops_warnings(enabled=True)
+        self.assertNotEqual(
+            analyzer.warn_skipped,
+            analyzer_copy.warn_skipped,
+            "Changing setting from .copy() changed original too.",
+        )
+
+        # Copy with new model and inputs
+        new_model = NonForwardNet()
+        bs = 5
+        new_inputs = (torch.randn((bs, *new_model.input_size)),)
+        analyzer_new = analyzer.copy(new_model=new_model, new_inputs=new_inputs)
+
+        non_forward_flops = new_model.fc_flops + new_model.submod.fc_flops
+
+        # Total is correct for new model and inputs
+        self.assertAlmostEqual(
+            analyzer_new.total(),
+            non_forward_flops * bs / 1e9,
+            msg=".copy() with new model/inputs gives incorrect results.",
+        )
+
+        # Original is unaffected
+        self.assertAlmostEqual(
+            analyzer.total(),
+            repeated_net_flops / 1e9,
+            msg=".copy() with new model/inputs changed original.",
+        )
+
+        # Settings match
+        self.assertEqual(
+            analyzer.warn_skipped,
+            analyzer_new.warn_skipped,
+            ".copy() gives JitModelAnalysis with different warning settings.",
+        )
+
+        self.assertEqual(
+            analyzer.warn_trace,
+            analyzer_new.warn_trace,
+            ".copy() gives JitModelAnalysis with different warning settings.",
+        )
+
+    def test_disable_warnings(self) -> None:
+        """
+        Tests .skipped_ops_warnings(...) and .tracer_warnings(...)
+        """
+        model = TraceWarningNet()
+        inputs = (torch.randn((1, *model.input_size)),)
+        ops_handles = {
+            "aten::addmm": addmm_flop_jit,
+        }
+
+        analyzer = JitModelAnalysis(model=model, inputs=inputs, ops_handles=ops_handles)
+
+        # Tracer warnings
+        analyzer.tracer_warnings(enabled=False)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = analyzer.total()
+            warning_types = [s.category for s in w]
+            self.assertFalse(
+                torch.jit._trace.TracerWarning in warning_types,
+                "TracerWarning was not correctly suppressed.",
+            )
+
+        analyzer.tracer_warnings(enabled=True)
+        analyzer.counts = None  # Manually clear cache so trace is rerun
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = analyzer.total()
+            warning_types = [s.category for s in w]
+            self.assertTrue(
+                torch.jit._trace.TracerWarning in warning_types,
+                "TracerWarning was incorrectly suppressed.",
+            )
+
+        # Skipped ops warnings
+        analyzer.skipped_ops_warnings(enabled=False)
+
+        logger = logging.getLogger()
+        log_stream = StringIO()
+        handler = logging.StreamHandler(stream=log_stream)
+        handler.setLevel(logging.WARNING)
+        logger.addHandler(handler)
+        skipped_string = "Skipped operation aten::add 1 time(s)"
+
+        _ = analyzer.total()
+        self.assertFalse(
+            skipped_string in log_stream.getvalue(),
+            "Skipped op warning was not correctly suppressed.",
+        )
+
+        analyzer.skipped_ops_warnings(enabled=True)
+
+        _ = analyzer.total()
+        self.assertTrue(
+            skipped_string in log_stream.getvalue(),
+            "Skipped op warning was incorrectly suppressed.",
+        )
+
+        logger.removeHandler(handler)


### PR DESCRIPTION
Here's an implementation of how to obtain the per-module information from the jit trace. The class in `fvcore/nn/jit_analysis.py` can return per-module and per-operator information for generic calculation handles acting on operators in the model's trace graph.

The trace calculation and analysis step has been moved from `fvcore/nn/jit_handles.py` to `fvcore/nn/jit_analysis.py`. Functions to construct specific counters for flops and activations are defined in `fvcore/nn/flop_count.py` and `fvcore/nn/activation_count.py`.