### PR TITLE
Fix Edge Case when iter is at MAX_ITER

### DIFF
--- a/fvcore/common/param_scheduler.py
+++ b/fvcore/common/param_scheduler.py
@@ -56,7 +56,7 @@ class ConstantParamScheduler(ParamScheduler):
         self._value = value
 
     def __call__(self, where: float) -> float:
-        if where >= 1.0:
+        if (where - self.WHERE_EPSILON) >= 1.0:
             raise RuntimeError(
                 f"where in ParamScheduler must be in [0, 1]: got {where}"
             )


### PR DESCRIPTION
Context:
I used ConstantParamScheduler as my baseline scheduler in a detectron2-based repository.

For example: cfg.SOLVER.MAX_ITER = 80,000

When self.iter is at 79,999 and triggers after_step(), it will display a runtime error as shown below:

```bash
RuntimeError: Invalid where parameter for scheduler: 1.0
```

I've learned that it's due to the fact that the self.last_epoch of the scheduler is always ahead by 1 relative to self.iter of the trainer.

To resolve this, by reducing `where` by self.EPSILON_WHERE, the result value becomes 0.999999.