### PR TITLE
fix pypi package release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,12 +45,10 @@ install_dep: &install_dep
 
 install_fvcore: &install_fvcore
   - run:
-      environment:
-        BUILD_NIGHTLY: 1
       name: Install fvcore
       command: |
+        BUILD_NIGHTLY=1 python setup.py sdist
         pip install . -U
-        python setup.py sdist
         python -c 'import fvcore; print(fvcore.__version__)'
 
 run_unittests: &run_unittests


### PR DESCRIPTION
The pypi package https://pypi.org/project/fvcore/ has not been updated for a while.
This is because CI creates package with invalid name, e.g. https://app.circleci.com/pipelines/github/facebookresearch/fvcore/920/workflows/651c790b-758d-4fa0-9471-3317d0280868/jobs/3059/parallel-runs/0/steps/0-106 has  `fvcore-0.1.5.post20220106.post20220106.post20220106/`.

The name is now normal with this commit, shown in https://app.circleci.com/pipelines/github/facebookresearch/fvcore/921/workflows/cb411117-6c4a-48b8-b5d0-486322b0d952/jobs/3064.

The gpu tests are failing due to pre-existing docker error (there is an internal task on it).
