### PR TITLE
Fix circleci gpu resource name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ gpu: &gpu
   machine:
     image: ubuntu-1604:201903-01
     docker_layer_caching: true
-  resource_class: gpu.small
+  resource_class: gpu.nvidia.small
 
 # -------------------------------------------------------------------------------------
 # Re-usable commands


### PR DESCRIPTION
Nightly is [not running](https://app.circleci.com/pipelines/github/facebookresearch/fvcore/958/workflows/500ea691-281d-4052-9118-cc21ef03f7b8/jobs/3205) due to:
![2022-02-10_11-31](https://user-images.githubusercontent.com/1381301/153482740-c973754b-74ea-4160-a4ad-65fa6760b12f.png)

Changed it according to https://github.com/facebookresearch/detectron2/blob/ef2c3abbd36d4093a604f874243037691f634c2f/.circleci/config.yml#L15