### PR TITLE
Change ConstantParamScheduler to exclude 1

### DIFF
--- a/fvcore/common/param_scheduler.py
+++ b/fvcore/common/param_scheduler.py
@@ -56,7 +56,7 @@ class ConstantParamScheduler(ParamScheduler):
         self._value = value
 
     def __call__(self, where: float) -> float:
-        if where >= 1.0:
+        if where > 1.0:
             raise RuntimeError(
                 f"where in ParamScheduler must be in [0, 1]: got {where}"
             )


### PR DESCRIPTION
At the end of the training, `where == 1.0`.