### PR TITLE
add flop counter for mul operation

### DIFF
--- a/fvcore/nn/activation_count.py
+++ b/fvcore/nn/activation_count.py
@@ -19,6 +19,9 @@ _DEFAULT_SUPPORTED_OPS: Dict[str, Handle] = {
     "aten::einsum": generic_activation_jit(),
     "aten::matmul": generic_activation_jit(),
     "aten::linear": generic_activation_jit(),
+    "aten::mm": generic_activation_jit(),
+    "aten::mul": generic_activation_jit(),
+    "aten::mul_": generic_activation_jit(),
 }
 
 

--- a/fvcore/nn/flop_count.py
+++ b/fvcore/nn/flop_count.py
@@ -19,7 +19,6 @@ from .jit_handles import (
     linear_flop_jit,
     matmul_flop_jit,
     norm_flop_counter,
-    mul_flop_jit,
 )
 
 
@@ -32,8 +31,8 @@ _DEFAULT_SUPPORTED_OPS: Dict[str, Handle] = {
     "aten::matmul": matmul_flop_jit,
     "aten::mm": matmul_flop_jit,
     "aten::linear": linear_flop_jit,
-    "aten::mul": mul_flop_jit,
-    "aten::mul_": mul_flop_jit,
+    "aten::mul": elementwise_flop_counter(0, 1),
+    "aten::mul_": elementwise_flop_counter(0, 1),
     # You might want to ignore BN flops due to inference-time fusion.
     # Use `set_op_handle("aten::batch_norm", None)
     "aten::batch_norm": batchnorm_flop_jit,

--- a/fvcore/nn/flop_count.py
+++ b/fvcore/nn/flop_count.py
@@ -19,6 +19,7 @@ from .jit_handles import (
     linear_flop_jit,
     matmul_flop_jit,
     norm_flop_counter,
+    mul_flop_jit,
 )
 
 
@@ -31,6 +32,8 @@ _DEFAULT_SUPPORTED_OPS: Dict[str, Handle] = {
     "aten::matmul": matmul_flop_jit,
     "aten::mm": matmul_flop_jit,
     "aten::linear": linear_flop_jit,
+    "aten::mul": mul_flop_jit,
+    "aten::mul_": mul_flop_jit,
     # You might want to ignore BN flops due to inference-time fusion.
     # Use `set_op_handle("aten::batch_norm", None)
     "aten::batch_norm": batchnorm_flop_jit,

--- a/fvcore/nn/jit_handles.py
+++ b/fvcore/nn/jit_handles.py
@@ -227,22 +227,6 @@ def matmul_flop_jit(inputs: List[Any], outputs: List[Any]) -> Number:
     return flop
 
 
-def mul_flop_jit(inputs: List[Any], outputs: List[Any]) -> Number:
-    """
-    Count flops for the mul operation supporting broadcast.
-    """
-    # Inputs should be a list of length 2.
-    # Inputs contains the shapes of two tensor.
-    assert len(inputs) == 2, len(inputs)
-    input_shapes = [get_shape(v) for v in inputs]
-    shape_zero_len, shape_one_len = len(input_shapes[0]), len(input_shapes[1])
-    max_len = max(shape_zero_len, shape_one_len)
-    shape_zero_padded = np.pad(input_shapes[0], (max_len - shape_zero_len, 0), 'constant', constant_values=(1, 1))
-    shape_one_padded = np.pad(input_shapes[1], (max_len - shape_one_len, 0), 'constant', constant_values=(1, 1))
-    flop = int(prod(np.maximum(shape_zero_padded, shape_one_padded)))
-    return flop
-
-
 def norm_flop_counter(affine_arg_index: int) -> Handle:
     """
     Args:

--- a/fvcore/nn/jit_handles.py
+++ b/fvcore/nn/jit_handles.py
@@ -227,6 +227,22 @@ def matmul_flop_jit(inputs: List[Any], outputs: List[Any]) -> Number:
     return flop
 
 
+def mul_flop_jit(inputs: List[Any], outputs: List[Any]) -> Number:
+    """
+    Count flops for the mul operation supporting broadcast.
+    """
+    # Inputs should be a list of length 2.
+    # Inputs contains the shapes of two tensor.
+    assert len(inputs) == 2, len(inputs)
+    input_shapes = [get_shape(v) for v in inputs]
+    shape_zero_len, shape_one_len = len(input_shapes[0]), len(input_shapes[1])
+    max_len = max(shape_zero_len, shape_one_len)
+    shape_zero_padded = np.pad(input_shapes[0], (max_len - shape_zero_len, 0), 'constant', constant_values=(1, 1))
+    shape_one_padded = np.pad(input_shapes[1], (max_len - shape_one_len, 0), 'constant', constant_values=(1, 1))
+    flop = int(prod(np.maximum(shape_zero_padded, shape_one_padded)))
+    return flop
+
+
 def norm_flop_counter(affine_arg_index: int) -> Handle:
     """
     Args:

--- a/tests/test_flop_count.py
+++ b/tests/test_flop_count.py
@@ -147,6 +147,17 @@ class BMMNet(nn.Module):
         return x
 
 
+class MulNet(nn.Module):
+    """
+    A network with a single torch.mul operation. This is used for testing
+    flop count for torch.mul.
+    """
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        x = torch.mul(x, y)
+        return x
+
+
 class CustomNet(nn.Module):
     """
     A network with a fully connected layer followed by a sigmoid layer. This is
@@ -703,6 +714,26 @@ class TestFlopCountAnalysis(unittest.TestCase):
             flop_dict,
             gt_dict,
             "Einsum operation ntg,ncg->nct failed to pass the flop count test.",
+        )
+
+    def test_mul(self) -> None:
+        """
+        Test flop count for operation torch.mul.
+        """
+        m = 2
+        n = 5
+        p = 7
+        net = MulNet()
+        x = torch.randn(m, 1, n)
+        y = torch.randn(p, 1)
+        flop_dict, _ = flop_count(net, (x, y))
+        gt_flop = m * n * p / 1e9
+        gt_dict = defaultdict(float)
+        gt_dict["mul"] = gt_flop
+        self.assertDictEqual(
+            flop_dict,
+            gt_dict,
+            "Mul operation failed to pass the flop count test."
         )
 
     def test_batchnorm(self) -> None:


### PR DESCRIPTION
Summary: add flop counter for elementwise product between tensors.

Though there is an implementation using `elementwise_flop_counter(1)` in [#99](https://github.com/facebookresearch/fvcore/pull/99), but it does not support broadcasting to a common shape.