### PR TITLE
Fix Shapely deprecation

### DIFF
--- a/fvcore/transforms/transform.py
+++ b/fvcore/transforms/transform.py
@@ -718,7 +718,9 @@ class CropTransform(Transform):
             cropped = polygon.intersection(crop_box)
             if cropped.is_empty:
                 continue
-            if not isinstance(cropped, geometry.collection.BaseMultipartGeometry):
+            if isinstance(cropped, geometry.collection.BaseMultipartGeometry):
+                cropped = cropped.geoms
+            else:
                 cropped = [cropped]
             # one polygon may be cropped to multiple ones
             for poly in cropped:


### PR DESCRIPTION
Directly iterating over multipart geometries is being removed in an upcoming version of Shapely and triggers excessive warnings with current versions of Shapely. Switching to iterating over the `.geoms` field as suggested by the migration guide: https://shapely.readthedocs.io/en/stable/migration.html#multi-part-geometries-will-no-longer-be-sequences-length-iterable-indexable