### PR TITLE
support loading checkpoint from non-local file directly.

### DIFF
--- a/fvcore/__init__.py
+++ b/fvcore/__init__.py
@@ -2,4 +2,4 @@
 
 # This line will be programatically read/write by setup.py.
 # Leave them at the bottom of this file and don't touch them.
-__version__ = "0.1.5"
+__version__ = "0.1.6"

--- a/fvcore/common/checkpoint.py
+++ b/fvcore/common/checkpoint.py
@@ -148,10 +148,7 @@ class Checkpointer:
             self.logger.info("No checkpoint found. Initializing model from scratch")
             return {}
         self.logger.info("[Checkpointer] Loading from {} ...".format(path))
-        if not os.path.isfile(path):
-            path = self.path_manager.get_local_path(path)
-            assert os.path.isfile(path), "Checkpoint {} not found!".format(path)
-
+        # path may not be a local file, but _load_file is responsible to handle it.
         checkpoint = self._load_file(path)
         incompatible = self._load_model(checkpoint)
         if (
@@ -249,7 +246,8 @@ class Checkpointer:
                 the checkpointer dict["model"] must be a dict which maps strings
                 to torch.Tensor or numpy arrays.
         """
-        return torch.load(f, map_location=torch.device("cpu"))
+        with self.path_manager.open(f, "rb") as file:
+            return torch.load(file, map_location=torch.device("cpu"))
 
     def _load_model(self, checkpoint: Any) -> _IncompatibleKeys:
         """

--- a/fvcore/common/checkpoint.py
+++ b/fvcore/common/checkpoint.py
@@ -247,7 +247,7 @@ class Checkpointer:
                 to torch.Tensor or numpy arrays.
         """
         with self.path_manager.open(f, "rb") as file:
-            return torch.load(file, map_location=torch.device("cpu"))
+            return torch.load(cast(IO[bytes], file), map_location=torch.device("cpu"))
 
     def _load_model(self, checkpoint: Any) -> _IncompatibleKeys:
         """


### PR DESCRIPTION
This is roughly a revert of https://github.com/facebookresearch/fvcore/commit/fd5043ff8b2e6790f5bd7c9632695c68986cc658, except that the `isfile` check is removed completely.

The original issue in https://github.com/facebookresearch/detectron2/pull/4712/files is that fvcore has a `isfile` check that does not work with d2's URL schema. 

The previous fix is to download the path to local such that `isfile` will pass. However that prevents me from loading a large checkpoint that doesn't fit to disk.

It's fine to just remove the check, since the file will be opened immediately (either by `self.path_manager` or by a subclass's `_load_file`) anyway: as long as `open` works, it doesn't matter if `isfile` works or not.

