### PR TITLE
fix formatting for values <1000

### DIFF
--- a/fvcore/nn/print_model_statistics.py
+++ b/fvcore/nn/print_model_statistics.py
@@ -49,7 +49,7 @@ def _format_size(x: int, sig_figs: int = 3, hide_zero: bool = False) -> str:
         return fmt(x / 1e6) + "M"
     if abs(x) > 1e2:
         return fmt(x / 1e3) + "K"
-    return str(x)
+    return fmt(x)
 
 
 def _pretty_statistics(


### PR DESCRIPTION
Fixes a small formatting issues for values below 1000. The number of significant digit would be ignored.

```
# Before 
print(_format_size(4.843658346, sig_figs=3)) --> 4.843658346
# After
print(_format_size(4.843658346, sig_figs=3)) --> 4.844
```